### PR TITLE
Improve parameter names

### DIFF
--- a/src/tidytcells/_utils/parameter.py
+++ b/src/tidytcells/_utils/parameter.py
@@ -10,6 +10,12 @@ class Parameter:
     def is_specified(self) -> bool:
         return self.value is not None
 
+    def set_default(self, default_value: any) -> "Parameter":
+        if not self.is_specified:
+            self.value = default_value
+
+        return self
+
     def resolve_with_alias(self, alias_value: any, alias_name: str) -> "Parameter":
         if alias_value is not None:
             if self.is_specified:
@@ -18,7 +24,7 @@ class Parameter:
                     "The latter will be deprecated in the near future, and replaced by the former. "
                     "Both parameters were passed values, so disregarding that of the latter. "
                     f'Please exclusively use "{self.name}" in the future.',
-                    FutureWarning
+                    FutureWarning,
                 )
             else:
                 warnings.warn(
@@ -31,17 +37,21 @@ class Parameter:
 
     def throw_error_if_not_of_type(
         self, object_type: type, optional: bool = False
-    ) -> None:
+    ) -> "Parameter":
         if optional and self.value is None:
-            return
+            return self
 
         if not isinstance(self.value, object_type):
             raise TypeError(
                 f'"{self.name}" must be of type {object_type}, got {self.value} ({type(self.value)}).'
             )
 
-    def throw_error_if_not_one_of(self, *allowed_values) -> None:
+        return self
+
+    def throw_error_if_not_one_of(self, *allowed_values) -> "Parameter":
         if not self.value in allowed_values:
             raise ValueError(
                 f'"{self.name}" must be one of ({allowed_values}), got {self.value}.'
             )
+
+        return self

--- a/src/tidytcells/_utils/parameter.py
+++ b/src/tidytcells/_utils/parameter.py
@@ -10,18 +10,24 @@ class Parameter:
     def is_specified(self) -> bool:
         return self.value is not None
 
-    def resolve_with_alias_and_return_value(self, alias: "Parameter") -> any:
-        if self.is_specified:
-            return self.value
+    def resolve_with_alias(self, alias_value: any, alias_name: str) -> "Parameter":
+        if alias_value is not None:
+            if self.is_specified:
+                warnings.warn(
+                    f'The parameters "{self.name}" and "{alias_name}" are mutually exclusive. '
+                    "The latter will be deprecated in the near future, and replaced by the former. "
+                    "Both parameters were passed values, so disregarding that of the latter. "
+                    f'Please exclusively use "{self.name}" in the future.',
+                    FutureWarning
+                )
+            else:
+                warnings.warn(
+                    f'The parameter "{alias_name}" will be deprecated in the near future. Please use "{self.name}" instead.',
+                    FutureWarning,
+                )
+            self.value = alias_value
 
-        if alias.is_specified:
-            warnings.warn(
-                f'The parameter "{alias.name}" will be deprecated in the near future. Please use "{self.name}" instead.',
-                FutureWarning,
-            )
-            return alias.value
-
-        return None
+        return self
 
     def throw_error_if_not_of_type(
         self, object_type: type, optional: bool = False

--- a/src/tidytcells/_utils/parameter.py
+++ b/src/tidytcells/_utils/parameter.py
@@ -6,32 +6,36 @@ class Parameter:
         self.value = value
         self.name = name
 
-    @property
-    def is_specified(self) -> bool:
-        return self.value is not None
+        if value is not None:
+            self.is_explicitly_set = True
+        else:
+            self.is_explicitly_set = False
 
     def set_default(self, default_value: any) -> "Parameter":
-        if not self.is_specified:
+        if not self.is_explicitly_set:
             self.value = default_value
 
         return self
 
     def resolve_with_alias(self, alias_value: any, alias_name: str) -> "Parameter":
-        if alias_value is not None:
-            if self.is_specified:
-                warnings.warn(
-                    f'The parameters "{self.name}" and "{alias_name}" are mutually exclusive. '
-                    "The latter will be deprecated in the near future, and replaced by the former. "
-                    "Both parameters were passed values, so disregarding that of the latter. "
-                    f'Please exclusively use "{self.name}" in the future.',
-                    FutureWarning,
-                )
-            else:
-                warnings.warn(
-                    f'The parameter "{alias_name}" will be deprecated in the near future. Please use "{self.name}" instead.',
-                    FutureWarning,
-                )
-            self.value = alias_value
+        if alias_value is None:
+            return self
+
+        if self.is_explicitly_set:
+            warnings.warn(
+                f'The parameters "{self.name}" and "{alias_name}" are mutually exclusive. '
+                "The latter will be deprecated in the near future, and replaced by the former. "
+                "Both parameters were passed values, so disregarding that of the latter. "
+                f'Please exclusively use "{self.name}" in the future.',
+                FutureWarning,
+            )
+            return self
+
+        warnings.warn(
+            f'The parameter "{alias_name}" will be deprecated in the near future. Please use "{self.name}" instead.',
+            FutureWarning,
+        )
+        self.value = alias_value
 
         return self
 

--- a/src/tidytcells/junction/_standardize.py
+++ b/src/tidytcells/junction/_standardize.py
@@ -103,7 +103,7 @@ def standardize(
     """
     original_input = seq
 
-    seq = aa.standardize(seq=seq, on_fail="reject", suppress_warnings=suppress_warnings)
+    seq = aa.standardize(seq=seq, on_fail="reject", log_failures=not suppress_warnings)
 
     not_valid_amino_acid_sequence = seq is None
     if not_valid_amino_acid_sequence:

--- a/src/tidytcells/junction/_standardize.py
+++ b/src/tidytcells/junction/_standardize.py
@@ -1,6 +1,9 @@
 import logging
 import re
 from tidytcells import aa
+from typing import Literal, Optional
+
+from tidytcells._utils.parameter import Parameter
 
 
 logger = logging.getLogger(__name__)
@@ -10,10 +13,11 @@ JUNCTION_MATCHING_REGEX = re.compile(f"^C[A-Z]*[FW]$")
 
 
 def standardize(
-    seq: str,
-    strict: bool = False,
-    on_fail: str = "reject",
-    suppress_warnings: bool = False,
+    seq: Optional[str] = None,
+    strict: Optional[bool] = None,
+    on_fail: Optional[Literal["reject", "keep"]] = None,
+    log_failures: Optional[bool] = None,
+    suppress_warnings: Optional[bool] = None,
 ):
     """
     Ensures that a string value looks like a valid junction (CDR3) amino acid sequence.
@@ -42,9 +46,14 @@ def standardize(
         Defaults to ``"reject"``.
     :type on_fail:
         str
+    :param log_failures:
+        Report standardisation failures through logging (at level ``WARNING``).
+        Defaults to ``True``.
+    :type log_failures:
+        bool
     :param suppress_warnings:
-        Disable warnings that are usually emitted when standardisation fails.
-        Defaults to ``False``.
+        Disable warnings that are usually logged when standardisation fails.
+        Deprecated in favour of `log_failures`.
     :type suppress_warnings:
         bool
 
@@ -101,9 +110,33 @@ def standardize(
                 IF on_fail is set to "keep":
                     RETURN original sequence
     """
+    seq = Parameter(seq, "seq").throw_error_if_not_of_type(str).value
+    strict = (
+        Parameter(strict, "strict")
+        .set_default(False)
+        .throw_error_if_not_of_type(bool)
+        .value
+    )
+    on_fail = (
+        Parameter(on_fail, "on_fail")
+        .set_default("reject")
+        .throw_error_if_not_of_type(str)
+        .value
+    )
+    suppress_warnings_inverted = (
+        not suppress_warnings if suppress_warnings is not None else None
+    )
+    log_failures = (
+        Parameter(log_failures, "log_failures")
+        .set_default(True)
+        .resolve_with_alias(suppress_warnings_inverted, "suppress_warnings")
+        .throw_error_if_not_of_type(bool)
+        .value
+    )
+
     original_input = seq
 
-    seq = aa.standardize(seq=seq, on_fail="reject", log_failures=not suppress_warnings)
+    seq = aa.standardize(seq=seq, on_fail="reject", log_failures=log_failures)
 
     not_valid_amino_acid_sequence = seq is None
     if not_valid_amino_acid_sequence:
@@ -113,7 +146,7 @@ def standardize(
 
     if not JUNCTION_MATCHING_REGEX.match(seq):
         if strict:
-            if not suppress_warnings:
+            if log_failures:
                 logger.warning(
                     f"Failed to standardize {original_input}: not a valid junction sequence."
                 )

--- a/src/tidytcells/mh/_get_chain.py
+++ b/src/tidytcells/mh/_get_chain.py
@@ -13,28 +13,39 @@ BETA_MATCHING_REGEX = re.compile(r"HLA-D[PQR]B|B2M")
 
 
 def get_chain(
+    symbol: Optional[str] = None,
+    log_failures: Optional[bool] = None,
     gene: Optional[str] = None,
-    suppress_warnings: bool = False,
+    suppress_warnings: Optional[bool] = None,
 ) -> str:
     """
-    Given a standardized MH gene name, detect whether it codes for an alpha chain, beta chain, or beta-2 microglobulin (B2M) molecule.
+    Given a standardized MH gene / allele symbol, detect whether it codes for an alpha chain, beta chain, or beta-2 microglobulin (B2M) molecule.
 
     .. note::
 
         This function currently only recognises HLA (human leucocyte antigen or *Homo sapiens* MH), and not MH from other species.
 
+    :param symbol:
+        Standardized MH gene / allele symbol
+    :type symbol:
+        str
+    :param log_failures:
+        Report standardisation failures through logging (at level ``WARNING``).
+        Defaults to ``True``.
+    :type log_failures:
+        bool
     :param gene:
-        Standardized MH gene name
+        Alias for `symbol`.
     :type gene:
         str
     :param suppress_warnings:
-        Disable warnings that are usually emitted when chain classification fails.
-        Defaults to ``False``.
+        Disable warnings that are usually logged when standardisation fails.
+        Deprecated in favour of `log_failures`.
     :type suppress_warnings:
         bool
 
     :return:
-        ``'alpha'`` or ``'beta'`` if ``gene`` is recognised and its chain is known, else ``None``.
+        ``'alpha'`` or ``'beta'`` if `symbol` is recognised and its chain is known, else ``None``.
     :rtype:
         Union[str, None]
 
@@ -47,21 +58,26 @@ def get_chain(
         >>> tt.mh.get_chain("B2M")
         'beta'
     """
-    Parameter(gene, "gene").throw_error_if_not_of_type(str)
+    symbol = Parameter(symbol, "symbol").resolve_with_alias(gene, "gene").throw_error_if_not_of_type(str).value
+    suppress_warnings_inverted = (
+        not suppress_warnings if suppress_warnings is not None else None
+    )
+    log_failures = Parameter(log_failures, "log_failures").set_default(True).resolve_with_alias(suppress_warnings_inverted, "suppress_warnings").throw_error_if_not_of_type(bool).value
 
-    gene = gene.split("*")[0]
+    symbol = symbol.split("*")[0]
 
-    if not gene in (*VALID_HOMOSAPIENS_MH, "B2M"):
-        if not suppress_warnings:
-            logger.warning(f"Unrecognized gene {gene}. Is this standardized?")
+    if not symbol in (*VALID_HOMOSAPIENS_MH, "B2M"):
+        if log_failures:
+            logger.warning(f"Unrecognized gene {symbol}. Is this standardized?")
         return None
 
-    if ALPHA_MATCHING_REGEX.match(gene):
+    if ALPHA_MATCHING_REGEX.match(symbol):
         return "alpha"
 
-    if BETA_MATCHING_REGEX.match(gene):
+    if BETA_MATCHING_REGEX.match(symbol):
         return "beta"
 
-    if not suppress_warnings:
-        logger.warning(f"Chain for {gene} unknown.")
+    if log_failures:
+        logger.warning(f"Chain for {symbol} unknown.")
+
     return None

--- a/src/tidytcells/mh/_get_chain.py
+++ b/src/tidytcells/mh/_get_chain.py
@@ -58,11 +58,22 @@ def get_chain(
         >>> tt.mh.get_chain("B2M")
         'beta'
     """
-    symbol = Parameter(symbol, "symbol").resolve_with_alias(gene, "gene").throw_error_if_not_of_type(str).value
+    symbol = (
+        Parameter(symbol, "symbol")
+        .resolve_with_alias(gene, "gene")
+        .throw_error_if_not_of_type(str)
+        .value
+    )
     suppress_warnings_inverted = (
         not suppress_warnings if suppress_warnings is not None else None
     )
-    log_failures = Parameter(log_failures, "log_failures").set_default(True).resolve_with_alias(suppress_warnings_inverted, "suppress_warnings").throw_error_if_not_of_type(bool).value
+    log_failures = (
+        Parameter(log_failures, "log_failures")
+        .set_default(True)
+        .resolve_with_alias(suppress_warnings_inverted, "suppress_warnings")
+        .throw_error_if_not_of_type(bool)
+        .value
+    )
 
     symbol = symbol.split("*")[0]
 

--- a/src/tidytcells/mh/_query.py
+++ b/src/tidytcells/mh/_query.py
@@ -1,6 +1,4 @@
 import re
-from typing import Dict, FrozenSet, Optional, Type
-
 from tidytcells import _utils
 from tidytcells._utils import Parameter
 from tidytcells._query_engine import (
@@ -8,6 +6,7 @@ from tidytcells._query_engine import (
     HlaQueryEngine,
     MusMusculusMhQueryEngine,
 )
+from typing import Dict, FrozenSet, Optional, Type, Literal
 
 
 QUERY_ENGINES: Dict[str, Type[QueryEngine]] = {
@@ -18,7 +17,7 @@ QUERY_ENGINES: Dict[str, Type[QueryEngine]] = {
 
 def query(
     species: Optional[str] = None,
-    precision: Optional[str] = None,
+    precision: Optional[Literal["allele", "gene"]] = None,
     contains_pattern: Optional[str] = None,
 ) -> FrozenSet[str]:
     """
@@ -102,4 +101,5 @@ def query(
         return result
 
     results_containing_substring = [i for i in result if re.search(contains_pattern, i)]
+
     return frozenset(results_containing_substring)

--- a/src/tidytcells/mh/_query.py
+++ b/src/tidytcells/mh/_query.py
@@ -71,11 +71,23 @@ def query(
         >>> tt.mh.query(species="musmusculus", precision="gene", contains_pattern="MH1-Q")
         frozenset({'MH1-Q3', 'MH1-Q9', 'MH1-Q1', 'MH1-Q2', 'MH1-Q6', 'MH1-Q10', 'MH1-Q5', 'MH1-Q8', 'MH1-Q7', 'MH1-Q4'})
     """
-    species = Parameter(species, "species").set_default("homosapiens").throw_error_if_not_of_type(str).value
-    precision = Parameter(precision, "precision").set_default("allele").throw_error_if_not_one_of("allele", "gene").value
-    contains_pattern = Parameter(contains_pattern, "contains_pattern").throw_error_if_not_of_type(
-        str, optional=True
-    ).value
+    species = (
+        Parameter(species, "species")
+        .set_default("homosapiens")
+        .throw_error_if_not_of_type(str)
+        .value
+    )
+    precision = (
+        Parameter(precision, "precision")
+        .set_default("allele")
+        .throw_error_if_not_one_of("allele", "gene")
+        .value
+    )
+    contains_pattern = (
+        Parameter(contains_pattern, "contains_pattern")
+        .throw_error_if_not_of_type(str, optional=True)
+        .value
+    )
 
     species = _utils.clean_and_lowercase(species)
 

--- a/src/tidytcells/mh/_query.py
+++ b/src/tidytcells/mh/_query.py
@@ -17,12 +17,12 @@ QUERY_ENGINES: Dict[str, Type[QueryEngine]] = {
 
 
 def query(
-    species: str = "homosapiens",
-    precision: str = "allele",
+    species: Optional[str] = None,
+    precision: Optional[str] = None,
     contains_pattern: Optional[str] = None,
 ) -> FrozenSet[str]:
     """
-    Query the list of all known MH genes/alleles.
+    Query the list of all known MH genes / alleles.
 
     .. topic:: Supported species
 
@@ -49,13 +49,13 @@ def query(
         str
     :param contains_pattern:
         An optional **regular expression** string which will be used to filter the query result.
-        If supplied, only genes/alleles which contain the regular expression will be returned.
+        If supplied, only genes / alleles which contain the regular expression will be returned.
         Defaults to ``None``.
     :type contains_pattern:
         str
 
     :return:
-        The set of all genes/alleles that satisfy the given constraints.
+        The set of all genes / alleles that satisfy the given constraints.
     :rtype:
         FrozenSet[str]
 
@@ -71,11 +71,11 @@ def query(
         >>> tt.mh.query(species="musmusculus", precision="gene", contains_pattern="MH1-Q")
         frozenset({'MH1-Q3', 'MH1-Q9', 'MH1-Q1', 'MH1-Q2', 'MH1-Q6', 'MH1-Q10', 'MH1-Q5', 'MH1-Q8', 'MH1-Q7', 'MH1-Q4'})
     """
-    Parameter(species, "species").throw_error_if_not_of_type(str)
-    Parameter(precision, "precision").throw_error_if_not_one_of("allele", "gene")
-    Parameter(contains_pattern, "contains_pattern").throw_error_if_not_of_type(
+    species = Parameter(species, "species").set_default("homosapiens").throw_error_if_not_of_type(str).value
+    precision = Parameter(precision, "precision").set_default("allele").throw_error_if_not_one_of("allele", "gene").value
+    contains_pattern = Parameter(contains_pattern, "contains_pattern").throw_error_if_not_of_type(
         str, optional=True
-    )
+    ).value
 
     species = _utils.clean_and_lowercase(species)
 

--- a/src/tidytcells/mh/_standardize.py
+++ b/src/tidytcells/mh/_standardize.py
@@ -19,14 +19,15 @@ SUPPORTED_SPECIES_AND_THEIR_STANDARDIZERS: Dict[str, Type[StandardizedGeneSymbol
 
 
 def standardize(
-    gene: Optional[str] = None,
+    symbol: Optional[str] = None,
     species: str = "homosapiens",
     precision: str = "allele",
     on_fail: str = "reject",
     suppress_warnings: bool = False,
+    gene: Optional[str] = None,
 ) -> tuple:
     """
-    Attempt to standardize an MH gene name to be IMGT-compliant.
+    Attempt to standardize an MH gene / allele symbol to be IMGT-compliant.
 
     .. topic:: Supported species
 
@@ -38,9 +39,9 @@ def standardize(
         Any further precise allele designations will not be verified, apart from the requirement that the format (colon-separated numbers) look valid.
         The reasons for this is firstly because new alleles at that level are added to the IMGT list quite often and so accurate verification is difficult, secondly because people rarely need verification to such a precise level, and finally because such verification costs more computational effort with diminishing returns.
 
-    :param gene:
-        Potentially non-standardized MH gene name.
-    :type gene:
+    :param symbol:
+        Potentially non-standardized MH gene / allele symbol.
+    :type symbol:
         str
     :param species:
         Species to which the MH gene belongs (see above for supported species).
@@ -67,22 +68,26 @@ def standardize(
         Defaults to ``False``.
     :type suppress_warnings:
         bool
+    :param gene:
+        Alias for `symbol`.
+    :type gene:
+        str
 
     :return:
-        If the specified ``species`` is supported, and ``gene`` could be standardized, then return the standardized gene name.
-        If ``species`` is unsupported, then the function does not attempt to standardize, and returns the unaltered ``gene`` string.
-        Else follows the behvaiour as set by ``on_fail``.
+        If the specified `species` is supported, and `symbol` could be standardized, then return the standardized symbol.
+        If `species` is unsupported, then the function does not attempt to standardize, and returns the unaltered `symbol` string.
+        Else follows the behvaiour as set by `on_fail`.
     :rtype:
         Union[str, None]
 
     .. topic:: Example usage
 
-        Input strings will intelligently be corrected to IMGT-compliant gene symbols.
+        Input strings will intelligently be corrected to IMGT-compliant symbols.
 
         >>> tt.mh.standardize("A1")
         'HLA-A*01'
 
-        The ``precision`` setting can truncate unnecessary information.
+        The `precision` setting can truncate unnecessary information.
 
         >>> tt.mh.standardize("HLA-A*01", precision="gene")
         'HLA-A'
@@ -100,31 +105,31 @@ def standardize(
         .. code-block:: none
 
             IF the specified species is not supported for standardization:
-                RETURN original gene symbol without modification
+                RETURN original symbol without modification
 
             ELSE:
                 // attempt standardization
                 {
-                    IF gene symbol is already in IMGT-compliant form:
+                    IF symbol is already in IMGT-compliant form:
                         set standardization status as successful
                         skip rest of standardization
 
-                    IF gene symbol is a known deprecated symbol:
-                        overwrite gene symbol with current IMGT-compliant symbol
+                    IF symbol is a known deprecated symbol:
+                        overwrite symbol with current IMGT-compliant symbol
                         set standardization status as successful
                         skip rest of standardization
 
                     // the rest is only applicable when species is set to homo sapiens
-                    add "HLA-" to the beginning of the gene symbol if necessary             //e.g. A -> HLA-A
+                    add "HLA-" to the beginning of the symbol if necessary                  //e.g. A -> HLA-A
                     replace "Cw" with "C"                                                   //e.g. HLA-Cw -> HLA-C
                     add back forgotten asterisks if necessary                               //e.g. HLA-A01 -> HLA-A*01
                     add back forgotten colons if necessary                                  //e.g. HLA-A*0101 -> HLA-A*01:01
-                    If gene symbol is now in IMGT-compliant form:
+                    If symbol is now in IMGT-compliant form:
                         set standardization status as successful
                         skip rest of standardization
 
                     try adding or subtracting leading zeros from allele designation numbers //e.g. HLA-A*001 -> HLA-A*01
-                    If gene symbol is now in IMGT-compliant form:
+                    If symbol is now in IMGT-compliant form:
                         set standardization status as successful
                         skip rest of standardization
 
@@ -132,21 +137,44 @@ def standardize(
                 }
 
                 IF standardization status is set to successful:
-                    RETURN standardized gene symbol
+                    RETURN standardized symbol
 
                 ELSE:
                     IF on_fail is set to "reject":
                         RETURN None
                     IF on_fail is set to "keep":
-                        RETURN original gene symbol without modification
+                        RETURN original symbol without modification
     """
-    Parameter(gene, "gene").throw_error_if_not_of_type(str)
-    Parameter(species, "species").throw_error_if_not_of_type(str)
-    Parameter(precision, "precision").throw_error_if_not_one_of(
-        "allele", "protein", "gene"
+    symbol = (
+        Parameter(symbol, "symbol")
+        .resolve_with_alias(gene, "gene")
+        .throw_error_if_not_of_type(str)
+        .value
     )
-    Parameter(on_fail, "on_fail").throw_error_if_not_one_of("reject", "keep")
-    Parameter(suppress_warnings, "suppress_warnings").throw_error_if_not_of_type(bool)
+    species = (
+        Parameter(species, "species")
+        .set_default("homosapiens")
+        .throw_error_if_not_of_type(str)
+        .value
+    )
+    precision = (
+        Parameter(precision, "precision")
+        .set_default("allele")
+        .throw_error_if_not_one_of("allele", "protein", "gene")
+        .value
+    )
+    on_fail = (
+        Parameter(on_fail, "on_fail")
+        .set_default("reject")
+        .throw_error_if_not_one_of("reject", "keep")
+        .value
+    )
+    suppress_warnings = (
+        Parameter(suppress_warnings, "suppress_warnings")
+        .set_default(False)
+        .throw_error_if_not_of_type(bool)
+        .value
+    )
 
     species = _utils.clean_and_lowercase(species)
 
@@ -154,24 +182,24 @@ def standardize(
     if not species_is_supported:
         if not suppress_warnings:
             _utils.warn_unsupported_species(species, "MH", logger)
-        return gene
+        return symbol
 
     StandardizedMhSymbolClass = SUPPORTED_SPECIES_AND_THEIR_STANDARDIZERS[species]
-    standardized_mh_symbol = StandardizedMhSymbolClass(gene)
+    standardized_mh_symbol = StandardizedMhSymbolClass(symbol)
 
     invalid_reason = standardized_mh_symbol.get_reason_why_invalid()
     if invalid_reason is not None:
         if not suppress_warnings:
             _utils.warn_failure(
                 reason_for_failure=invalid_reason,
-                original_input=gene,
+                original_input=symbol,
                 attempted_fix=standardized_mh_symbol.compile("allele"),
                 species=species,
                 logger=logger,
             )
         if on_fail == "reject":
             return None
-        return gene
+        return symbol
 
     return standardized_mh_symbol.compile(precision)
 

--- a/src/tidytcells/mh/_standardize.py
+++ b/src/tidytcells/mh/_standardize.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Dict, Optional, Type
 from tidytcells import _utils
 from tidytcells._utils import Parameter
 from tidytcells._standardized_gene_symbol import (
@@ -7,6 +6,7 @@ from tidytcells._standardized_gene_symbol import (
     StandardizedHlaSymbol,
     StandardizedMusMusculusMhSymbol,
 )
+from typing import Dict, Optional, Type, Literal
 
 
 logger = logging.getLogger(__name__)
@@ -21,8 +21,8 @@ SUPPORTED_SPECIES_AND_THEIR_STANDARDIZERS: Dict[str, Type[StandardizedGeneSymbol
 def standardize(
     symbol: Optional[str] = None,
     species: Optional[str] = None,
-    precision: Optional[str] = None,
-    on_fail: Optional[str] = None,
+    precision: Optional[Literal["allele", "protein", "gene"]] = None,
+    on_fail: Optional[Literal["reject", "keep"]] = None,
     log_failures: Optional[bool] = None,
     gene: Optional[str] = None,
     suppress_warnings: Optional[bool] = None,

--- a/src/tidytcells/tr/_get_aa_sequence.py
+++ b/src/tidytcells/tr/_get_aa_sequence.py
@@ -13,9 +13,13 @@ SUPPORTED_SPECIES_AND_THEIR_AA_SEQUENCES = {
 }
 
 
-def get_aa_sequence(symbol: Optional[str] = None, species: str = "homosapiens", gene: Optional[str] = None) -> Dict[str, str]:
+def get_aa_sequence(
+    symbol: Optional[str] = None,
+    species: str = "homosapiens",
+    gene: Optional[str] = None,
+) -> Dict[str, str]:
     """
-    Look up the amino acid sequence of a given TR gene.
+    Look up the amino acid sequence of a given TR allele.
 
     .. topic:: Supported species
 
@@ -23,8 +27,8 @@ def get_aa_sequence(symbol: Optional[str] = None, species: str = "homosapiens", 
         - ``"musmusculus"``
 
     :param symbol:
-        Standardized gene / allele symbol.
-        The symbol must be specified to the level of the allele.
+        Standardized allele symbol.
+        Note that the symbol must be specified to the level of the allele.
         Note that some alleles, notably those of non-functional genes, will not have resolvable amino acid sequences.
     :type symbol:
         str
@@ -55,8 +59,18 @@ def get_aa_sequence(symbol: Optional[str] = None, species: str = "homosapiens", 
         >>> tt.tr.get_aa_sequence(gene="TRAJ32*02", species="musmusculus")
         {'FR4-IMGT': 'FGTGTLLSVKP', 'J-REGION': 'NYGGSGNKLIFGTGTLLSVKP'}
     """
-    symbol = Parameter(symbol, "symbol").resolve_with_alias(gene, "gene").throw_error_if_not_of_type(str).value
-    species = Parameter(species, "species").set_default("homosapiens").throw_error_if_not_of_type(str).value
+    symbol = (
+        Parameter(symbol, "symbol")
+        .resolve_with_alias(gene, "gene")
+        .throw_error_if_not_of_type(str)
+        .value
+    )
+    species = (
+        Parameter(species, "species")
+        .set_default("homosapiens")
+        .throw_error_if_not_of_type(str)
+        .value
+    )
 
     species = _utils.clean_and_lowercase(species)
 

--- a/src/tidytcells/tr/_get_aa_sequence.py
+++ b/src/tidytcells/tr/_get_aa_sequence.py
@@ -1,11 +1,10 @@
-from typing import Dict
-
 from tidytcells._resources import (
     HOMOSAPIENS_TR_AA_SEQUENCES,
     MUSMUSCULUS_TR_AA_SEQUENCES,
 )
 from tidytcells import _utils
 from tidytcells._utils import Parameter
+from typing import Dict, Optional
 
 
 SUPPORTED_SPECIES_AND_THEIR_AA_SEQUENCES = {
@@ -14,7 +13,7 @@ SUPPORTED_SPECIES_AND_THEIR_AA_SEQUENCES = {
 }
 
 
-def get_aa_sequence(gene: str, species: str = "homosapiens") -> Dict[str, str]:
+def get_aa_sequence(symbol: Optional[str] = None, species: str = "homosapiens", gene: Optional[str] = None) -> Dict[str, str]:
     """
     Look up the amino acid sequence of a given TR gene.
 
@@ -23,20 +22,24 @@ def get_aa_sequence(gene: str, species: str = "homosapiens") -> Dict[str, str]:
         - ``"homosapiens"``
         - ``"musmusculus"``
 
-    :param gene:
-        Standardized gene name.
-        The gene must be specified to the level of the allele.
-        Note that some genes, notably the non-functional ones, will not have resolvable amino acid sequences.
-    :type gene:
+    :param symbol:
+        Standardized gene / allele symbol.
+        The symbol must be specified to the level of the allele.
+        Note that some alleles, notably those of non-functional genes, will not have resolvable amino acid sequences.
+    :type symbol:
         str
     :param species:
         Species to which the TR gene in question belongs (see above for supported species).
         Defaults to ``"homosapiens"``.
     :type species:
         str
+    :param gene:
+        Alias for `symbol`.
+    :type gene:
+        str
 
     :return:
-        A dictionary with keys corresponding to names of different sequence regions within the gene, and values corresponding to their amino acid sequences.
+        A dictionary with keys corresponding to names of different sequence regions within the allele, and values corresponding to their amino acid sequences.
     :rtype:
         Dict[str, str]
 
@@ -52,8 +55,8 @@ def get_aa_sequence(gene: str, species: str = "homosapiens") -> Dict[str, str]:
         >>> tt.tr.get_aa_sequence(gene="TRAJ32*02", species="musmusculus")
         {'FR4-IMGT': 'FGTGTLLSVKP', 'J-REGION': 'NYGGSGNKLIFGTGTLLSVKP'}
     """
-    Parameter(gene, "gene").throw_error_if_not_of_type(str)
-    Parameter(species, "species").throw_error_if_not_of_type(str)
+    symbol = Parameter(symbol, "symbol").resolve_with_alias(gene, "gene").throw_error_if_not_of_type(str).value
+    species = Parameter(species, "species").set_default("homosapiens").throw_error_if_not_of_type(str).value
 
     species = _utils.clean_and_lowercase(species)
 
@@ -63,7 +66,7 @@ def get_aa_sequence(gene: str, species: str = "homosapiens") -> Dict[str, str]:
 
     aa_sequence_dict = SUPPORTED_SPECIES_AND_THEIR_AA_SEQUENCES[species]
 
-    if gene in aa_sequence_dict:
-        return aa_sequence_dict[gene]
+    if symbol in aa_sequence_dict:
+        return aa_sequence_dict[symbol]
 
-    raise ValueError(f"No data found for TR gene {gene} for species {species}.")
+    raise ValueError(f"No data found for TR gene {symbol} for species {species}.")

--- a/src/tidytcells/tr/_query.py
+++ b/src/tidytcells/tr/_query.py
@@ -17,13 +17,13 @@ QUERY_ENGINES: Dict[str, Type[QueryEngine]] = {
 
 
 def query(
-    species: str = "homosapiens",
-    precision: str = "allele",
-    functionality: str = "any",
+    species: Optional[str] = None,
+    precision: Optional[str] = None,
+    functionality: Optional[str] = None,
     contains_pattern: Optional[str] = None,
 ) -> FrozenSet[str]:
     """
-    Query the list of all known TR genes/alleles.
+    Query the list of all known TR genes / alleles.
 
     .. topic:: Supported species
 
@@ -62,7 +62,7 @@ def query(
         str
 
     :return:
-        The set of all genes/alleles that satisfy the given constraints.
+        The set of all genes / alleles that satisfy the given constraints.
     :rtype:
         FrozenSet[str]
 
@@ -78,13 +78,28 @@ def query(
         >>> tt.tr.query(species="musmusculus", precision="gene", functionality="ORF", contains_pattern="TRAV")
         frozenset({'TRAV21/DV12', 'TRAV14D-1', 'TRAV13-3', 'TRAV9D-2', 'TRAV5D-4', 'TRAV12D-3', 'TRAV12-1', 'TRAV18', 'TRAV11D'})
     """
-    Parameter(species, "species").throw_error_if_not_of_type(str)
-    Parameter(precision, "precision").throw_error_if_not_one_of("allele", "gene")
-    Parameter(functionality, "functionality").throw_error_if_not_one_of(
-        "any", "F", "NF", "P", "ORF"
+    species = (
+        Parameter(species, "species")
+        .set_default("homosapiens")
+        .throw_error_if_not_of_type(str)
+        .value
     )
-    Parameter(contains_pattern, "contains_pattern").throw_error_if_not_of_type(
-        str, optional=True
+    precision = (
+        Parameter(precision, "precision")
+        .set_default("allele")
+        .throw_error_if_not_one_of("allele", "gene")
+        .value
+    )
+    functionality = (
+        Parameter(functionality, "functionality")
+        .set_default("any")
+        .throw_error_if_not_one_of("any", "F", "NF", "P", "ORF")
+        .value
+    )
+    contains_pattern = (
+        Parameter(contains_pattern, "contains_pattern")
+        .throw_error_if_not_of_type(str, optional=True)
+        .value
     )
 
     species = _utils.clean_and_lowercase(species)

--- a/src/tidytcells/tr/_standardize.py
+++ b/src/tidytcells/tr/_standardize.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Dict, Optional, Type, Literal
 from tidytcells import _utils
 from tidytcells._utils import Parameter
 from tidytcells._standardized_gene_symbol import (
@@ -7,6 +6,7 @@ from tidytcells._standardized_gene_symbol import (
     StandardizedHomoSapiensTrSymbol,
     StandardizedMusMusculusTrSymbol,
 )
+from typing import Dict, Optional, Type, Literal
 
 
 logger = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ def standardize(
     species: Optional[str] = None,
     enforce_functional: Optional[bool] = None,
     precision: Optional[Literal["allele", "gene"]] = None,
-    on_fail: Optional[str] = None,
+    on_fail: Optional[Literal["reject", "keep"]] = None,
     log_failures: Optional[str] = None,
     gene: Optional[str] = None,
     suppress_warnings: Optional[bool] = None,

--- a/src/tidytcells/tr/_standardize.py
+++ b/src/tidytcells/tr/_standardize.py
@@ -199,10 +199,13 @@ def standardize(
         .throw_error_if_not_one_of("reject", "keep")
         .value
     )
+    suppress_warnings_inverted = (
+        not suppress_warnings if suppress_warnings is not None else None
+    )
     log_failures = (
         Parameter(log_failures, "log_failures")
         .set_default(True)
-        .resolve_with_alias(not suppress_warnings, "suppress_warnings")
+        .resolve_with_alias(suppress_warnings_inverted, "suppress_warnings")
         .throw_error_if_not_of_type(bool)
         .value
     )

--- a/src/tidytcells/tr/_standardize.py
+++ b/src/tidytcells/tr/_standardize.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional, Type
+from typing import Dict, Optional, Type, Literal
 from tidytcells import _utils
 from tidytcells._utils import Parameter
 from tidytcells._standardized_gene_symbol import (
@@ -19,32 +19,34 @@ SUPPORTED_SPECIES_AND_THEIR_STANDARDIZERS: Dict[str, Type[StandardizedGeneSymbol
 
 
 def standardize(
+    symbol: Optional[str] = None,
+    species: Optional[str] = None,
+    enforce_functional: Optional[bool] = None,
+    precision: Optional[Literal["allele", "gene"]] = None,
+    on_fail: Optional[str] = None,
+    log_failures: Optional[str] = None,
     gene: Optional[str] = None,
-    species: str = "homosapiens",
-    enforce_functional: bool = False,
-    precision: str = "allele",
-    on_fail: str = "reject",
-    suppress_warnings: bool = False,
+    suppress_warnings: Optional[bool] = None,
 ) -> str:
     """
-    Attempt to standardize a TR gene name to be IMGT-compliant.
+    Attempt to standardize a TR gene / allele symbol to be IMGT-compliant.
 
     .. topic:: Supported species
 
         - ``"homosapiens"``
         - ``"musmusculus"``
 
-    :param gene:
-        Potentially non-standardized TR gene name.
-    :type gene:
+    :param symbol:
+        Potentially non-standardized TR gene / allele symbol.
+    :type symbol:
         str
     :param species:
-        Species to which the TR gene belongs (see above for supported species).
+        Species to which the TR gene / allele belongs (see above for supported species).
         Defaults to ``"homosapiens"``.
     :type species:
         str
     :param enforce_functional:
-        If ``True``, disallows TR genes that are recognised by IMGT but are marked as non-functional (ORF or pseudogene).
+        If ``True``, disallows TR genes / alleles that are recognised by IMGT but are marked as non-functional (ORF or pseudogene).
         Defaults to ``False``.
     :type enforce_functional:
         bool
@@ -62,32 +64,41 @@ def standardize(
         Defaults to ``"reject"``.
     :type on_fail:
         str
+    :param log_failures:
+        Report standardisation failures through logging (at level ``WARNING``).
+        Defaults to ``True``.
+    :type log_failures:
+        bool
+    :param gene:
+        Alias for the parameter `symbol`.
+    :type gene:
+        str
     :param suppress_warnings:
-        Disable warnings that are usually emitted when standardisation fails.
-        Defaults to ``False``.
+        Disable warnings that are usually logged when standardisation fails.
+        Deprecated in favour of `log_failures`.
     :type suppress_warnings:
         bool
 
     :return:
-        If the specified ``species`` is supported, and ``gene`` could be standardized, then return the standardized gene name.
-        If ``species`` is unsupported, then the function does not attempt to standardize , and returns the unaltered ``gene`` string.
-        Else follows the behaviour as set by ``on_fail``.
+        If the specified `species` is supported, and `symbol` could be standardized, then return the standardized symbol name.
+        If `species` is unsupported, then the function does not attempt to standardize , and returns the unaltered `symbol` string.
+        Else follows the behaviour as set by `on_fail`.
     :rtype:
         Union[str, None]
 
     .. topic:: Example usage
 
-        Input strings will intelligently be corrected to IMGT-compliant gene symbols.
+        Input strings will intelligently be corrected to IMGT-compliant gene / allele symbols.
 
         >>> tt.tr.standardize("aj1")
         'TRAJ1'
 
-        The ``precision`` setting can truncate unnecessary information.
+        The `precision` setting can truncate unnecessary information.
 
         >>> tt.tr.standardize("TRBV6-4*01", precision="gene")
         'TRBV6-4'
 
-        The ``enforce_functional`` setting will cause non-functional genes or alleles to be rejected.
+        The `enforce_functional` setting will cause non-functional genes or alleles to be rejected.
 
         >>> result = tt.tr.standardize("TRBV1", enforce_functional=True)
         UserWarning: Failed to standardize "TRBV1" for species homosapiens: gene has no functional alleles. Attempted fix "TRBV1".
@@ -107,17 +118,17 @@ def standardize(
         .. code-block:: none
 
             IF the specified species is not supported for standardization:
-                RETURN original gene symbol without modification
+                RETURN original symbol without modification
 
             ELSE:
                 // attempt standardization
                 {
-                    IF gene symbol is already in IMGT-compliant form:
+                    IF symbol is already in IMGT-compliant form:
                         set standardization status as successful
                         skip rest of standardization
 
-                    IF gene symbol is a known deprecated symbol:
-                        overwrite gene symbol with current IMGT-compliant symbol
+                    IF symbol is a known deprecated symbol:
+                        overwrite symbol with current IMGT-compliant symbol
                         set standardization status as successful
                         skip rest of standardization
 
@@ -126,23 +137,23 @@ def standardize(
                     replace "." with "-"                                        //e.g. TRAV1.1 -> TRAV1-1
                     add back any missing backslashes                            //e.g. TRAV14DV4 -> TRAV14/DV4
                     remove any unnecessary trailing zeros                       //e.g. TRAV1-01 -> TRAV1-1
-                    IF gene symbol is now in IMGT-compliant form:
+                    IF symbol is now in IMGT-compliant form:
                         set standardization status as successful
                         skip rest of standardization
 
 
-                    add "TR" to the beginning of the gene symbol if necessary   //e.g. AV1-1 -> TRAV1-1
-                    IF gene symbol is now in IMGT-compliant form:
+                    add "TR" to the beginning of the symbol if necessary   //e.g. AV1-1 -> TRAV1-1
+                    IF symbol is now in IMGT-compliant form:
                         set standardization status as successful
                         skip rest of standardization
 
                     resolve compound TRAV/TRDV designation if necessary         //e.g. TRDV4 -> TRAV14/DV4 or TRAV14 -> TRAV14/DV4
-                    IF gene symbol is now in IMGT-compliant form:
+                    IF symbol is now in IMGT-compliant form:
                         set standardization as successful
                         skip rest of standardization
 
-                    try adding or removing "-1" from the end of the gene symbol //e.g. TRAV1 -> TRAV1-1
-                    IF gene symbol is now in IMGT-compliant form:
+                    try adding or removing "-1" from the end of the symbol //e.g. TRAV1 -> TRAV1-1
+                    IF symbol is now in IMGT-compliant form:
                         set standardization status as successful
                         skip rest of standardization
 
@@ -150,45 +161,76 @@ def standardize(
                 }
 
                 IF standardization status is set to successful:
-                    RETURN standardized gene symbol
+                    RETURN standardized symbol
 
                 ELSE:
                     IF on_fail is set to "reject":
                         RETURN None
                     IF on_fail is set to "keep":
-                        RETURN original gene symbol without modification
+                        RETURN original symbol without modification
     """
-    Parameter(gene, "gene").throw_error_if_not_of_type(str)
-    Parameter(species, "species").throw_error_if_not_of_type(str)
-    Parameter(enforce_functional, "enforce_functional").throw_error_if_not_of_type(bool)
-    Parameter(precision, "precision").throw_error_if_not_one_of("allele", "gene")
-    Parameter(on_fail, "on_fail").throw_error_if_not_one_of("reject", "keep")
-    Parameter(suppress_warnings, "suppress_warnings").throw_error_if_not_of_type(bool)
+    symbol = (
+        Parameter(symbol, "symbol")
+        .resolve_with_alias(gene, "gene")
+        .throw_error_if_not_of_type(str)
+        .value
+    )
+    species = (
+        Parameter(species, "species")
+        .set_default("homosapiens")
+        .throw_error_if_not_of_type(str)
+        .value
+    )
+    enforce_functional = (
+        Parameter(enforce_functional, "enforce_functional")
+        .set_default(False)
+        .throw_error_if_not_of_type(bool)
+        .value
+    )
+    precision = (
+        Parameter(precision, "precision")
+        .set_default("allele")
+        .throw_error_if_not_one_of("allele", "gene")
+        .value
+    )
+    on_fail = (
+        Parameter(on_fail, "on_fail")
+        .set_default("reject")
+        .throw_error_if_not_one_of("reject", "keep")
+        .value
+    )
+    log_failures = (
+        Parameter(log_failures, "log_failures")
+        .set_default(True)
+        .resolve_with_alias(not suppress_warnings, "suppress_warnings")
+        .throw_error_if_not_of_type(bool)
+        .value
+    )
 
     species = _utils.clean_and_lowercase(species)
 
     species_is_supported = species in SUPPORTED_SPECIES_AND_THEIR_STANDARDIZERS
     if not species_is_supported:
-        if not suppress_warnings:
+        if log_failures:
             _utils.warn_unsupported_species(species, "TR", logger)
-        return gene
+        return symbol
 
     StandardizedTrSymbolClass = SUPPORTED_SPECIES_AND_THEIR_STANDARDIZERS[species]
-    standardized_tr_symbol = StandardizedTrSymbolClass(gene)
+    standardized_tr_symbol = StandardizedTrSymbolClass(symbol)
 
     invalid_reason = standardized_tr_symbol.get_reason_why_invalid(enforce_functional)
     if invalid_reason is not None:
-        if not suppress_warnings:
+        if log_failures:
             _utils.warn_failure(
                 reason_for_failure=invalid_reason,
-                original_input=gene,
+                original_input=symbol,
                 attempted_fix=standardized_tr_symbol.compile("allele"),
                 species=species,
                 logger=logger,
             )
         if on_fail == "reject":
             return None
-        return gene
+        return symbol
 
     return standardized_tr_symbol.compile(precision)
 

--- a/tests/test_aa.py
+++ b/tests/test_aa.py
@@ -4,7 +4,7 @@ from tidytcells import aa
 
 class TestStandardise:
     @pytest.mark.parametrize("seq", ("KLGGALQAK", "LLQTGIHVRVSQPSL", "SQLLNAKYL"))
-    def test_alreadY_correct(self, seq):
+    def test_already_correct(self, seq):
         result = aa.standardize(seq=seq)
 
         assert result == seq
@@ -31,8 +31,8 @@ class TestStandardise:
 
         assert result == "KLGAK"
 
-    def test_suppress_warnings(self, caplog):
-        aa.standardize(seq="123456", suppress_warnings=True)
+    def test_log_failures(self, caplog):
+        aa.standardize(seq="123456", log_failures=False)
         assert len(caplog.records) == 0
 
     def test_on_fail(self, caplog):

--- a/tests/test_junction.py
+++ b/tests/test_junction.py
@@ -2,7 +2,7 @@ import pytest
 from tidytcells import junction
 
 
-class TestStandardise:
+class Teststandardize:
     @pytest.mark.parametrize(
         "seq",
         (
@@ -15,13 +15,13 @@ class TestStandardise:
         ),
     )
     def test_already_correct(self, seq):
-        result = junction.standardise(seq=seq)
+        result = junction.standardize(seq=seq)
 
         assert result == seq
 
     @pytest.mark.parametrize("seq", ("123456", "ASDFGHJKL", "A?AAAA", "AAAXAA"))
     def test_various_rejections(self, seq, caplog):
-        result = junction.standardise(seq=seq)
+        result = junction.standardize(seq=seq)
         assert "not a valid amino acid sequence" in caplog.text
         assert result is None
 
@@ -35,18 +35,18 @@ class TestStandardise:
         ),
     )
     def test_various_corrections(self, seq, expected):
-        result = junction.standardise(seq=seq)
+        result = junction.standardize(seq=seq)
 
         assert result == expected
 
     @pytest.mark.parametrize("seq", (None, 1, True, 5.4))
     def test_bad_input_type(self, seq):
         with pytest.raises(TypeError):
-            junction.standardise(seq=seq)
+            junction.standardize(seq=seq)
 
     @pytest.mark.parametrize("seq", ("ASQY", "CASQY", "ASQYF", "ASQYW"))
     def test_strict(self, seq, caplog):
-        result = junction.standardise(seq=seq, strict=True)
+        result = junction.standardize(seq=seq, strict=True)
         assert "not a valid junction" in caplog.text
         assert result is None
 
@@ -55,8 +55,8 @@ class TestStandardise:
 
         assert result == "CASSPGGADRRIDGYTF"
 
-    def test_suppress_warnings(self, caplog):
-        junction.standardise(seq="123456", suppress_warnings=True)
+    def test_log_failures(self, caplog):
+        junction.standardize(seq="123456", log_failures=False)
         assert len(caplog.records) == 0
 
     def test_on_fail(self, caplog):

--- a/tests/test_mh.py
+++ b/tests/test_mh.py
@@ -38,8 +38,8 @@ class TestStandardize:
 
         assert result == "HLA-B*07"
 
-    def test_suppress_warnings(self, caplog):
-        mh.standardize("foobarbaz", suppress_warnings=True)
+    def test_log_failures(self, caplog):
+        mh.standardize("foobarbaz", log_failures=False)
         assert len(caplog.records) == 0
 
     def test_on_fail(self, caplog):

--- a/tests/test_mh.py
+++ b/tests/test_mh.py
@@ -29,7 +29,9 @@ class TestStandardize:
         ),
     )
     def test_precision(self, symbol, expected, precision):
-        result = mh.standardize(symbol=symbol, species="homosapiens", precision=precision)
+        result = mh.standardize(
+            symbol=symbol, species="homosapiens", precision=precision
+        )
 
         assert result == expected
 

--- a/tests/test_mh.py
+++ b/tests/test_mh.py
@@ -206,13 +206,13 @@ class TestGetChain:
         ),
     )
     def test_get_chain(self, gene, expected):
-        result = mh.get_chain(gene=gene)
+        result = mh.get_chain(symbol=gene)
 
         assert result == expected
 
     @pytest.mark.parametrize("gene", ("foo", "HLA", "0"))
     def test_unrecognised_gene_names(self, gene, caplog):
-        result = mh.get_chain(gene=gene)
+        result = mh.get_chain(symbol=gene)
         assert "Unrecognized gene" in caplog.text
         assert result == None
 
@@ -221,8 +221,8 @@ class TestGetChain:
         with pytest.raises(TypeError):
             mh.get_chain(gene)
 
-    def test_suppress_warnings(self, caplog):
-        mh.get_chain("foobarbaz", suppress_warnings=True)
+    def test_log_failures(self, caplog):
+        mh.get_chain("foobarbaz", log_failures=False)
         assert len(caplog.records) == 0
 
 

--- a/tests/test_mh.py
+++ b/tests/test_mh.py
@@ -6,14 +6,14 @@ from tidytcells._resources import *
 class TestStandardize:
     @pytest.mark.parametrize("species", ("foobar", "yoinkdoink", ""))
     def test_unsupported_species(self, species, caplog):
-        result = mh.standardize(gene="HLA-A*01:01:01:01", species=species)
+        result = mh.standardize(symbol="HLA-A*01:01:01:01", species=species)
         assert "Unsupported" in caplog.text
         assert result == "HLA-A*01:01:01:01"
 
     @pytest.mark.parametrize("gene", (1234, None))
     def test_bad_type(self, gene):
         with pytest.raises(TypeError):
-            mh.standardize(gene=gene)
+            mh.standardize(symbol=gene)
 
     def test_default_homosapiens(self):
         result = mh.standardize("HLA-B*07")
@@ -29,7 +29,7 @@ class TestStandardize:
         ),
     )
     def test_precision(self, gene, expected, precision):
-        result = mh.standardize(gene=gene, species="homosapiens", precision=precision)
+        result = mh.standardize(symbol=gene, species="homosapiens", precision=precision)
 
         assert result == expected
 
@@ -51,7 +51,7 @@ class TestStandardize:
 class TestStandardizeHomoSapiens:
     @pytest.mark.parametrize("gene", [*VALID_HOMOSAPIENS_MH, "B2M"])
     def test_already_correctly_formatted(self, gene):
-        result = mh.standardize(gene=gene, species="homosapiens")
+        result = mh.standardize(symbol=gene, species="homosapiens")
 
         assert result == gene
 
@@ -59,13 +59,13 @@ class TestStandardizeHomoSapiens:
         "gene", ("foobar", "yoinkdoink", "HLA-FOOBAR123456", "=======")
     )
     def test_invalid_mh(self, gene, caplog):
-        result = mh.standardize(gene=gene, species="homosapiens")
+        result = mh.standardize(symbol=gene, species="homosapiens")
         assert "Failed to standardize" in caplog.text
         assert result == None
 
     @pytest.mark.parametrize("gene", ("HLA-A*01:01:1:1:1:1:1:1",))
     def test_bad_allele_designation(self, gene, caplog):
-        result = mh.standardize(gene=gene, species="homosapiens")
+        result = mh.standardize(symbol=gene, species="homosapiens")
         assert "Failed to standardize" in caplog.text
         assert result == None
 
@@ -79,7 +79,7 @@ class TestStandardizeHomoSapiens:
         ),
     )
     def test_fix_deprecated_names(self, gene, expected):
-        result = mh.standardize(gene=gene, species="homosapiens")
+        result = mh.standardize(symbol=gene, species="homosapiens")
 
         assert result == expected
 
@@ -95,7 +95,7 @@ class TestStandardizeHomoSapiens:
         ),
     )
     def test_remove_expression_qualifier(self, gene):
-        result = mh.standardize(gene=gene, species="homosapiens")
+        result = mh.standardize(symbol=gene, species="homosapiens")
 
         assert result == "HLA-A*01:01:01:01"
 
@@ -112,7 +112,7 @@ class TestStandardizeHomoSapiens:
         ),
     )
     def test_various_typos(self, gene, expected):
-        result = mh.standardize(gene=gene, species="homosapiens")
+        result = mh.standardize(symbol=gene, species="homosapiens")
 
         assert result == expected
 
@@ -120,13 +120,13 @@ class TestStandardizeHomoSapiens:
 class TestStandardizeMusMusculus:
     @pytest.mark.parametrize("gene", VALID_MUSMUSCULUS_MH)
     def test_already_correctly_formatted(self, gene):
-        result = mh.standardize(gene=gene, species="musmusculus")
+        result = mh.standardize(symbol=gene, species="musmusculus")
 
         assert result == gene
 
     @pytest.mark.parametrize("gene", ("foobar", "yoinkdoink", "MH1-ABC", "======="))
     def test_invalid_mh(self, gene, caplog):
-        result = mh.standardize(gene=gene, species="musmusculus")
+        result = mh.standardize(symbol=gene, species="musmusculus")
         assert "Failed to standardize" in caplog.text
         assert result == None
 
@@ -134,7 +134,7 @@ class TestStandardizeMusMusculus:
         ("gene", "expected"), (("H-2Eb1", "MH2-EB1"), ("H-2Aa", "MH2-AA"))
     )
     def test_fix_deprecated_names(self, gene, expected):
-        result = mh.standardize(gene=gene, species="musmusculus")
+        result = mh.standardize(symbol=gene, species="musmusculus")
 
         assert result == expected
 

--- a/tests/test_mh.py
+++ b/tests/test_mh.py
@@ -10,10 +10,10 @@ class TestStandardize:
         assert "Unsupported" in caplog.text
         assert result == "HLA-A*01:01:01:01"
 
-    @pytest.mark.parametrize("gene", (1234, None))
-    def test_bad_type(self, gene):
+    @pytest.mark.parametrize("symbol", (1234, None))
+    def test_bad_type(self, symbol):
         with pytest.raises(TypeError):
-            mh.standardize(symbol=gene)
+            mh.standardize(symbol=symbol)
 
     def test_default_homosapiens(self):
         result = mh.standardize("HLA-B*07")
@@ -21,15 +21,15 @@ class TestStandardize:
         assert result == "HLA-B*07"
 
     @pytest.mark.parametrize(
-        ("gene", "expected", "precision"),
+        ("symbol", "expected", "precision"),
         (
             ("HLA-DRB3*01:01:02:01", "HLA-DRB3*01:01:02:01", "allele"),
             ("HLA-DRB3*01:01:02:01", "HLA-DRB3*01:01", "protein"),
             ("HLA-DRB3*01:01:02:01", "HLA-DRB3", "gene"),
         ),
     )
-    def test_precision(self, gene, expected, precision):
-        result = mh.standardize(symbol=gene, species="homosapiens", precision=precision)
+    def test_precision(self, symbol, expected, precision):
+        result = mh.standardize(symbol=symbol, species="homosapiens", precision=precision)
 
         assert result == expected
 
@@ -49,28 +49,28 @@ class TestStandardize:
 
 
 class TestStandardizeHomoSapiens:
-    @pytest.mark.parametrize("gene", [*VALID_HOMOSAPIENS_MH, "B2M"])
-    def test_already_correctly_formatted(self, gene):
-        result = mh.standardize(symbol=gene, species="homosapiens")
+    @pytest.mark.parametrize("symbol", [*VALID_HOMOSAPIENS_MH, "B2M"])
+    def test_already_correctly_formatted(self, symbol):
+        result = mh.standardize(symbol=symbol, species="homosapiens")
 
-        assert result == gene
+        assert result == symbol
 
     @pytest.mark.parametrize(
-        "gene", ("foobar", "yoinkdoink", "HLA-FOOBAR123456", "=======")
+        "symbol", ("foobar", "yoinkdoink", "HLA-FOOBAR123456", "=======")
     )
-    def test_invalid_mh(self, gene, caplog):
-        result = mh.standardize(symbol=gene, species="homosapiens")
+    def test_invalid_mh(self, symbol, caplog):
+        result = mh.standardize(symbol=symbol, species="homosapiens")
         assert "Failed to standardize" in caplog.text
         assert result == None
 
-    @pytest.mark.parametrize("gene", ("HLA-A*01:01:1:1:1:1:1:1",))
-    def test_bad_allele_designation(self, gene, caplog):
-        result = mh.standardize(symbol=gene, species="homosapiens")
+    @pytest.mark.parametrize("symbol", ("HLA-A*01:01:1:1:1:1:1:1",))
+    def test_bad_allele_designation(self, symbol, caplog):
+        result = mh.standardize(symbol=symbol, species="homosapiens")
         assert "Failed to standardize" in caplog.text
         assert result == None
 
     @pytest.mark.parametrize(
-        ("gene", "expected"),
+        ("symbol", "expected"),
         (
             ("D6S204", "HLA-C"),
             ("HLA-DQA*01:01", "HLA-DQA1*01:01"),
@@ -78,13 +78,13 @@ class TestStandardizeHomoSapiens:
             ("HLA-DRA1*01:01", "HLA-DRA*01:01"),
         ),
     )
-    def test_fix_deprecated_names(self, gene, expected):
-        result = mh.standardize(symbol=gene, species="homosapiens")
+    def test_fix_deprecated_names(self, symbol, expected):
+        result = mh.standardize(symbol=symbol, species="homosapiens")
 
         assert result == expected
 
     @pytest.mark.parametrize(
-        "gene",
+        "symbol",
         (
             "HLA-A*01:01:01:01N",
             "HLA-A*01:01:01:01L",
@@ -94,13 +94,13 @@ class TestStandardizeHomoSapiens:
             "HLA-A*01:01:01:01Q",
         ),
     )
-    def test_remove_expression_qualifier(self, gene):
-        result = mh.standardize(symbol=gene, species="homosapiens")
+    def test_remove_expression_qualifier(self, symbol):
+        result = mh.standardize(symbol=symbol, species="homosapiens")
 
         assert result == "HLA-A*01:01:01:01"
 
     @pytest.mark.parametrize(
-        ("gene", "expected"),
+        ("symbol", "expected"),
         (
             ("HLA-B8", "HLA-B*08"),
             ("A*01:01", "HLA-A*01:01"),
@@ -111,30 +111,30 @@ class TestStandardizeHomoSapiens:
             ("HLA-A*01:01:1:1", "HLA-A*01:01:01:01"),
         ),
     )
-    def test_various_typos(self, gene, expected):
-        result = mh.standardize(symbol=gene, species="homosapiens")
+    def test_various_typos(self, symbol, expected):
+        result = mh.standardize(symbol=symbol, species="homosapiens")
 
         assert result == expected
 
 
 class TestStandardizeMusMusculus:
-    @pytest.mark.parametrize("gene", VALID_MUSMUSCULUS_MH)
-    def test_already_correctly_formatted(self, gene):
-        result = mh.standardize(symbol=gene, species="musmusculus")
+    @pytest.mark.parametrize("symbol", VALID_MUSMUSCULUS_MH)
+    def test_already_correctly_formatted(self, symbol):
+        result = mh.standardize(symbol=symbol, species="musmusculus")
 
-        assert result == gene
+        assert result == symbol
 
-    @pytest.mark.parametrize("gene", ("foobar", "yoinkdoink", "MH1-ABC", "======="))
-    def test_invalid_mh(self, gene, caplog):
-        result = mh.standardize(symbol=gene, species="musmusculus")
+    @pytest.mark.parametrize("symbol", ("foobar", "yoinkdoink", "MH1-ABC", "======="))
+    def test_invalid_mh(self, symbol, caplog):
+        result = mh.standardize(symbol=symbol, species="musmusculus")
         assert "Failed to standardize" in caplog.text
         assert result == None
 
     @pytest.mark.parametrize(
-        ("gene", "expected"), (("H-2Eb1", "MH2-EB1"), ("H-2Aa", "MH2-AA"))
+        ("symbol", "expected"), (("H-2Eb1", "MH2-EB1"), ("H-2Aa", "MH2-AA"))
     )
-    def test_fix_deprecated_names(self, gene, expected):
-        result = mh.standardize(symbol=gene, species="musmusculus")
+    def test_fix_deprecated_names(self, symbol, expected):
+        result = mh.standardize(symbol=symbol, species="musmusculus")
 
         assert result == expected
 
@@ -188,7 +188,7 @@ class TestQuery:
 
 class TestGetChain:
     @pytest.mark.parametrize(
-        ("gene", "expected"),
+        ("symbol", "expected"),
         (
             ("HLA-A", "alpha"),
             ("HLA-B", "alpha"),
@@ -205,21 +205,21 @@ class TestGetChain:
             ("B2M", "beta"),
         ),
     )
-    def test_get_chain(self, gene, expected):
-        result = mh.get_chain(symbol=gene)
+    def test_get_chain(self, symbol, expected):
+        result = mh.get_chain(symbol=symbol)
 
         assert result == expected
 
-    @pytest.mark.parametrize("gene", ("foo", "HLA", "0"))
-    def test_unrecognised_gene_names(self, gene, caplog):
-        result = mh.get_chain(symbol=gene)
+    @pytest.mark.parametrize("symbol", ("foo", "HLA", "0"))
+    def test_unrecognised_gene_names(self, symbol, caplog):
+        result = mh.get_chain(symbol=symbol)
         assert "Unrecognized gene" in caplog.text
         assert result == None
 
-    @pytest.mark.parametrize("gene", (1234, None))
-    def test_bad_type(self, gene):
+    @pytest.mark.parametrize("symbol", (1234, None))
+    def test_bad_type(self, symbol):
         with pytest.raises(TypeError):
-            mh.get_chain(gene)
+            mh.get_chain(symbol)
 
     def test_log_failures(self, caplog):
         mh.get_chain("foobarbaz", log_failures=False)
@@ -228,7 +228,7 @@ class TestGetChain:
 
 class TestGetClass:
     @pytest.mark.parametrize(
-        ("gene", "expected"),
+        ("symbol", "expected"),
         (
             ("HLA-A", 1),
             ("HLA-B", 1),
@@ -245,21 +245,21 @@ class TestGetClass:
             ("B2M", 1),
         ),
     )
-    def test_get_class(self, gene, expected):
-        result = mh.get_class(symbol=gene)
+    def test_get_class(self, symbol, expected):
+        result = mh.get_class(symbol=symbol)
 
         assert result == expected
 
-    @pytest.mark.parametrize("gene", ("foo", "HLA", "0"))
-    def test_unrecognised_gene_names(self, gene, caplog):
-        result = mh.get_class(symbol=gene)
+    @pytest.mark.parametrize("symbol", ("foo", "HLA", "0"))
+    def test_unrecognised_gene_names(self, symbol, caplog):
+        result = mh.get_class(symbol=symbol)
         assert "Unrecognized gene" in caplog.text
         assert result == None
 
-    @pytest.mark.parametrize("gene", (1234, None))
-    def test_bad_type(self, gene):
+    @pytest.mark.parametrize("symbol", (1234, None))
+    def test_bad_type(self, symbol):
         with pytest.raises(TypeError):
-            mh.get_class(gene)
+            mh.get_class(symbol)
 
     def test_log_failures(self, caplog):
         mh.get_class("foobarbaz", log_failures=False)

--- a/tests/test_mh.py
+++ b/tests/test_mh.py
@@ -246,13 +246,13 @@ class TestGetClass:
         ),
     )
     def test_get_class(self, gene, expected):
-        result = mh.get_class(gene=gene)
+        result = mh.get_class(symbol=gene)
 
         assert result == expected
 
     @pytest.mark.parametrize("gene", ("foo", "HLA", "0"))
     def test_unrecognised_gene_names(self, gene, caplog):
-        result = mh.get_class(gene=gene)
+        result = mh.get_class(symbol=gene)
         assert "Unrecognized gene" in caplog.text
         assert result == None
 
@@ -261,6 +261,6 @@ class TestGetClass:
         with pytest.raises(TypeError):
             mh.get_class(gene)
 
-    def test_suppress_warnings(self, caplog):
-        mh.get_class("foobarbaz", suppress_warnings=True)
+    def test_log_failures(self, caplog):
+        mh.get_class("foobarbaz", log_failures=False)
         assert len(caplog.records) == 0


### PR DESCRIPTION
* Deprecate parameter name `gene` to `symbol` in gene / allele symbol standardization functions
* Deprecate parameter `suppress_warnings` in favour of `log_failures` in all functions where this parameter is used
* Both above deprecations are soft deprecations for backwards compatibility, breaking changes will only come in next major release