### PR TITLE
Improve standardisation capability

### DIFF
--- a/src/tidytcells/_standardized_gene_symbol/__init__.py
+++ b/src/tidytcells/_standardized_gene_symbol/__init__.py
@@ -1,4 +1,4 @@
-from .standardized_gene_symbol import StandardizedGeneSymbol
+from .standardized_gene_symbol import StandardizedSymbol
 
 from .standardized_homo_sapiens_tr_symbol import StandardizedHomoSapiensTrSymbol
 from .standardized_mus_musculus_tr_symbol import StandardizedMusMusculusTrSymbol

--- a/src/tidytcells/_standardized_gene_symbol/standardized_gene_symbol.py
+++ b/src/tidytcells/_standardized_gene_symbol/standardized_gene_symbol.py
@@ -2,13 +2,13 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 
-class StandardizedGeneSymbol(ABC):
+class StandardizedSymbol(ABC):
     """
     Abstract base standardizer class.
     """
 
     @abstractmethod
-    def __init__(self, gene_symbol: str) -> None:
+    def __init__(self, symbol: str) -> None:
         pass
 
     @abstractmethod

--- a/src/tidytcells/_standardized_gene_symbol/standardized_hla_symbol.py
+++ b/src/tidytcells/_standardized_gene_symbol/standardized_hla_symbol.py
@@ -3,7 +3,7 @@ import re
 from typing import List, Optional
 
 from tidytcells import _utils
-from tidytcells._standardized_gene_symbol import StandardizedGeneSymbol
+from tidytcells._standardized_gene_symbol import StandardizedSymbol
 from tidytcells._resources import VALID_HOMOSAPIENS_MH, HOMOSAPIENS_MH_SYNONYMS
 
 
@@ -56,9 +56,9 @@ class HlaSymbolParser:
         ]
 
 
-class StandardizedHlaSymbol(StandardizedGeneSymbol):
-    def __init__(self, gene_symbol: str) -> None:
-        self._parse_hla_symbol(gene_symbol)
+class StandardizedHlaSymbol(StandardizedSymbol):
+    def __init__(self, symbol: str) -> None:
+        self._parse_hla_symbol(symbol)
         self._resolve_errors()
 
     def _parse_hla_symbol(self, hla_symbol: str) -> None:

--- a/src/tidytcells/_standardized_gene_symbol/standardized_mus_musculus_mh_symbol.py
+++ b/src/tidytcells/_standardized_gene_symbol/standardized_mus_musculus_mh_symbol.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from tidytcells import _utils
 from tidytcells._resources import VALID_MUSMUSCULUS_MH, MUSMUSCULUS_MH_SYNONYMS
-from tidytcells._standardized_gene_symbol import StandardizedGeneSymbol
+from tidytcells._standardized_gene_symbol import StandardizedSymbol
 
 
 class MhSymbolParser:
@@ -25,9 +25,9 @@ class MhSymbolParser:
             self.allele_designation = None
 
 
-class StandardizedMusMusculusMhSymbol(StandardizedGeneSymbol):
-    def __init__(self, gene_symbol: str) -> None:
-        self._parse_mh_symbol(gene_symbol)
+class StandardizedMusMusculusMhSymbol(StandardizedSymbol):
+    def __init__(self, symbol: str) -> None:
+        self._parse_mh_symbol(symbol)
         self._resolve_errors()
 
     def _parse_mh_symbol(self, mh_symbol: str) -> None:

--- a/src/tidytcells/mh/_standardize.py
+++ b/src/tidytcells/mh/_standardize.py
@@ -2,7 +2,7 @@ import logging
 from tidytcells import _utils
 from tidytcells._utils import Parameter
 from tidytcells._standardized_gene_symbol import (
-    StandardizedGeneSymbol,
+    StandardizedSymbol,
     StandardizedHlaSymbol,
     StandardizedMusMusculusMhSymbol,
 )
@@ -12,7 +12,7 @@ from typing import Dict, Optional, Type, Literal
 logger = logging.getLogger(__name__)
 
 
-SUPPORTED_SPECIES_AND_THEIR_STANDARDIZERS: Dict[str, Type[StandardizedGeneSymbol]] = {
+SUPPORTED_SPECIES_AND_THEIR_STANDARDIZERS: Dict[str, Type[StandardizedSymbol]] = {
     "homosapiens": StandardizedHlaSymbol,
     "musmusculus": StandardizedMusMusculusMhSymbol,
 }

--- a/src/tidytcells/tr/_standardize.py
+++ b/src/tidytcells/tr/_standardize.py
@@ -2,7 +2,7 @@ import logging
 from tidytcells import _utils
 from tidytcells._utils import Parameter
 from tidytcells._standardized_gene_symbol import (
-    StandardizedGeneSymbol,
+    StandardizedSymbol,
     StandardizedHomoSapiensTrSymbol,
     StandardizedMusMusculusTrSymbol,
 )
@@ -12,7 +12,7 @@ from typing import Dict, Optional, Type, Literal
 logger = logging.getLogger(__name__)
 
 
-SUPPORTED_SPECIES_AND_THEIR_STANDARDIZERS: Dict[str, Type[StandardizedGeneSymbol]] = {
+SUPPORTED_SPECIES_AND_THEIR_STANDARDIZERS: Dict[str, Type[StandardizedSymbol]] = {
     "homosapiens": StandardizedHomoSapiensTrSymbol,
     "musmusculus": StandardizedMusMusculusTrSymbol,
 }

--- a/tests/test_tr.py
+++ b/tests/test_tr.py
@@ -142,6 +142,19 @@ class TestStandardizeMusMusculus:
         assert result == None
 
 
+    @pytest.mark.parametrize(
+        ("symbol", "expected"),
+        (
+            ("TRAV15-1-DV6-1", "TRAV15-1/DV6-1"),
+            ("TRAV15/DV6", "TRAV15-1/DV6-1"),
+        ),
+    )
+    def test_corrections(self, symbol, expected):
+        result = tr.standardize(symbol=symbol, species="musmusculus")
+
+        assert result == expected
+
+
 class TestQuery:
     @pytest.mark.parametrize(
         ("species", "precision", "expected_len", "expected_in", "expected_not_in"),


### PR DESCRIPTION
* Previously tidytcells could not resolve "TRAV15-1-DV6-1" to "TRAV15-1/DV6-1", which it now can
* Previously tidytcells could not resolve "TRAV15/DV6" to "TRAV15-1/DV6-1", which it now can