### PR TITLE
Improve mh (hla) standardisation quality

### DIFF
--- a/src/tidytcells/_standardized_gene_symbol/standardized_tr_symbol.py
+++ b/src/tidytcells/_standardized_gene_symbol/standardized_tr_symbol.py
@@ -126,19 +126,19 @@ class StandardizedTrSymbol(StandardizedSymbol):
         ]
 
         dash1_candidates = []
-        for (numstr, start_idx, end_idx) in all_gene_nums:
+        for numstr, start_idx, end_idx in all_gene_nums:
             fm = re.fullmatch(r"(\d+)(-1)?", numstr)
             if not fm:
                 continue
             dash1_candidates.append((fm.group(1), start_idx, end_idx))
-        
+
         dash1_variants = []
         for comb in itertools.product(("dash", "nodash"), repeat=len(dash1_candidates)):
             num_comb_zip = zip(dash1_candidates, comb)
             current_str_idx = 0
             working_variant = ""
 
-            for ((numstr, start_idx, end_idx), status) in num_comb_zip:
+            for (numstr, start_idx, end_idx), status in num_comb_zip:
                 working_variant += self._gene_name[current_str_idx:start_idx]
 
                 if status == "dash":

--- a/tests/test_mh.py
+++ b/tests/test_mh.py
@@ -108,9 +108,11 @@ class TestStandardizeHomoSapiens:
             ("A*01:01", "HLA-A*01:01"),
             ("A1", "HLA-A*01"),
             ("HLA-B*5701", "HLA-B*57:01"),
+            ("HLA-DQA1*0501", "HLA-DQA1*05:01"),
             ("B35.3", "HLA-B*35:03"),
             ("HLA-DQB103:01", "HLA-DQB1*03:01"),
             ("HLA-A*01:01:1:1", "HLA-A*01:01:01:01"),
+            ("HLA-DRB*07:01", "HLA-DRB1*07:01"),
         ),
     )
     def test_various_typos(self, symbol, expected):

--- a/tests/test_tr.py
+++ b/tests/test_tr.py
@@ -141,7 +141,6 @@ class TestStandardizeMusMusculus:
         assert "Failed to standardize" in caplog.text
         assert result == None
 
-
     @pytest.mark.parametrize(
         ("symbol", "expected"),
         (


### PR DESCRIPTION
* Previously, tidytcells could not resolve "HLA-DQA1*0501" to "HLA-DQA1*05:01", which it now can
* Previously, tidytcells could not resolve "HLA-DRB*07:01" to "HLA-DRB1*07:01", which it now can