### PR TITLE
revert query engine warnings back to warnings.warn

### DIFF
--- a/src/tidytcells/_query_engine/hla_query_engine.py
+++ b/src/tidytcells/_query_engine/hla_query_engine.py
@@ -1,17 +1,14 @@
-import logging
 from typing import FrozenSet
 from tidytcells._query_engine import QueryEngine
 from tidytcells._resources import VALID_HOMOSAPIENS_MH
-
-
-logger = logging.getLogger(__name__)
+import warnings
 
 
 class HlaQueryEngine(QueryEngine):
     @classmethod
     def query(cls, precision: str, functionality: str) -> FrozenSet[str]:
         if precision == "allele":
-            logger.warning(
+            warnings.warn(
                 "tidytcells is not fully aware of all HLA alleles, and the "
                 "highest resolution it can provide is up to the level of the "
                 "protein (two allele designations)."

--- a/src/tidytcells/_query_engine/mus_musculus_mh_query_engine.py
+++ b/src/tidytcells/_query_engine/mus_musculus_mh_query_engine.py
@@ -1,17 +1,14 @@
-import logging
 from typing import FrozenSet
 from tidytcells._query_engine import QueryEngine
 from tidytcells._resources import VALID_MUSMUSCULUS_MH
-
-
-logger = logging.getLogger(__name__)
+import warnings
 
 
 class MusMusculusMhQueryEngine(QueryEngine):
     @classmethod
     def query(cls, precision: str, functionality: str) -> FrozenSet[str]:
         if precision == "allele":
-            logger.warning(
+            warnings.warn(
                 "tidytcells is not aware of Mus musculus MH alleles at all, "
                 "and can only provide up to the level of the gene."
             )


### PR DESCRIPTION
* These warnings are meant for the user and not helpful for later debugging therefore no reason to migrate to logger.warn