### PR TITLE
Implement species-agnostic TR and MH standardisation

### DIFF
--- a/tests/test_mh.py
+++ b/tests/test_mh.py
@@ -17,8 +17,20 @@ class TestStandardize:
 
     def test_default_homosapiens(self):
         result = mh.standardize("HLA-B*07")
-
         assert result == "HLA-B*07"
+
+    @pytest.mark.parametrize(
+        ("symbol", "expected"),
+        (
+            ("HLA-B8", "HLA-B*08"),
+            ("A1", "HLA-A*01"),
+            ("H-2Eb1", "MH2-EB1"),
+            ("H-2Aa", "MH2-AA")
+        )
+    )
+    def test_any_species(self, symbol, expected):
+        result = mh.standardize(symbol, species="any")
+        assert result == expected
 
     @pytest.mark.parametrize(
         ("symbol", "expected", "precision"),

--- a/tests/test_tr.py
+++ b/tests/test_tr.py
@@ -17,8 +17,20 @@ class TestStandardize:
 
     def test_default_homosapiens(self):
         result = tr.standardize("TRBV20/OR9-2*01")
-
         assert result == "TRBV20/OR9-2*01"
+
+    @pytest.mark.parametrize(
+        ("symbol", "expected"),
+        (
+            ("TRBV20/OR9-2*01", "TRBV20/OR9-2*01"),
+            ("TCRAV14/4", "TRAV14/DV4"),
+            ("TRAV15-1-DV6-1", "TRAV15-1/DV6-1"),
+            ("TRAV15/DV6", "TRAV15-1/DV6-1"),
+        )
+    )
+    def test_any_species(self, symbol, expected):
+        result = tr.standardize(symbol, species="any")
+        assert result == expected
 
     @pytest.mark.parametrize(
         ("symbol", "expected"),


### PR DESCRIPTION
* Implement an option to attempt standardisation allowing all supported species as targets
* The priority order of standardisation goes:
   * Homo sapiens
   * Mus musculus
* Closes #82 