### PR TITLE
Fix return type labels

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,3 +11,6 @@ python:
       path: .
       extra_requirements:
         - docs
+
+sphinx:
+  configuration: ./docs/conf.py

--- a/src/tidytcells/aa/_standardize.py
+++ b/src/tidytcells/aa/_standardize.py
@@ -42,7 +42,7 @@ def standardize(
         Capitalised version of `seq`, if seq is a valid amino acid sequence.
         Otherwise follow behaviour set by `on_fail`.
     :rtype:
-        Union[str, None]
+        Optional[str]
 
     .. topic:: Example usage
 

--- a/src/tidytcells/aa/_standardize.py
+++ b/src/tidytcells/aa/_standardize.py
@@ -12,7 +12,7 @@ def standardize(
     on_fail: Optional[Literal["reject", "keep"]] = None,
     log_failures: Optional[bool] = None,
     suppress_warnings: Optional[bool] = None,
-):
+) -> Optional[str]:
     """
     Ensures that a string value looks like a valid amino acid sequence.
 
@@ -99,7 +99,7 @@ def standardize(
     seq = seq.upper()
 
     for char in seq:
-        if not char in AMINO_ACIDS:
+        if char not in AMINO_ACIDS:
             if log_failures:
                 logger.warning(
                     f"Failed to standardize {original_input}: not a valid amino acid sequence."
@@ -111,7 +111,7 @@ def standardize(
     return seq
 
 
-def standardise(*args, **kwargs):
+def standardise(*args, **kwargs) -> Optional[str]:
     """
     Alias for :py:func:`tidytcells.aa.standardize`.
     """

--- a/src/tidytcells/junction/_standardize.py
+++ b/src/tidytcells/junction/_standardize.py
@@ -2,14 +2,13 @@ import logging
 import re
 from tidytcells import aa
 from typing import Literal, Optional
-
 from tidytcells._utils.parameter import Parameter
 
 
 logger = logging.getLogger(__name__)
 
 
-JUNCTION_MATCHING_REGEX = re.compile(f"^C[A-Z]*[FW]$")
+JUNCTION_MATCHING_REGEX = re.compile(r"^C[A-Z]*[FW]$")
 
 
 def standardize(
@@ -18,7 +17,7 @@ def standardize(
     on_fail: Optional[Literal["reject", "keep"]] = None,
     log_failures: Optional[bool] = None,
     suppress_warnings: Optional[bool] = None,
-):
+) -> Optional[str]:
     """
     Ensures that a string value looks like a valid junction (CDR3) amino acid sequence.
     This function is a special variant of :py:func:`tidytcells.aa.standardize`.
@@ -165,7 +164,7 @@ def standardize(
     return seq
 
 
-def standardise(*args, **kwargs):
+def standardise(*args, **kwargs) -> Optional[str]:
     """
     Alias for :py:func:`tidytcells.junction.standardize`.
     """

--- a/src/tidytcells/junction/_standardize.py
+++ b/src/tidytcells/junction/_standardize.py
@@ -60,7 +60,7 @@ def standardize(
         If possible, a standardized version of the input string is returned.
         If the input string cannot be standardized, the function follows the behaviour as set by `on_fail`.
     :rtype:
-        Union[str, None]
+        Optional[str]
 
     .. topic:: Example usage
 

--- a/src/tidytcells/mh/_get_chain.py
+++ b/src/tidytcells/mh/_get_chain.py
@@ -17,7 +17,7 @@ def get_chain(
     log_failures: Optional[bool] = None,
     gene: Optional[str] = None,
     suppress_warnings: Optional[bool] = None,
-) -> str:
+) -> Optional[str]:
     """
     Given a standardized MH gene / allele symbol, detect whether it codes for an alpha chain, beta chain, or beta-2 microglobulin (B2M) molecule.
 
@@ -47,7 +47,7 @@ def get_chain(
     :return:
         ``'alpha'`` or ``'beta'`` if `symbol` is recognised and its chain is known, else ``None``.
     :rtype:
-        Union[str, None]
+        Optional[str]
 
     .. topic:: Example usage
 
@@ -77,7 +77,7 @@ def get_chain(
 
     symbol = symbol.split("*")[0]
 
-    if not symbol in (*VALID_HOMOSAPIENS_MH, "B2M"):
+    if symbol not in (*VALID_HOMOSAPIENS_MH, "B2M"):
         if log_failures:
             logger.warning(f"Unrecognized gene {symbol}. Is this standardized?")
         return None

--- a/src/tidytcells/mh/_get_class.py
+++ b/src/tidytcells/mh/_get_class.py
@@ -17,7 +17,7 @@ def get_class(
     log_failures: Optional[bool] = None,
     gene: Optional[str] = None,
     suppress_warnings: Optional[bool] = None,
-) -> int:
+) -> Optional[int]:
     """
     Given a standardized MH gene / allele symbol, detect whether it comprises a class I (MH1) or II (MH2) receptor.
 
@@ -47,7 +47,7 @@ def get_class(
     :return:
         ``1`` or ``2`` if ``gene`` is recognised and its class is known, else ``None``.
     :rtype:
-        Union[int, None]
+        Optional[int]
 
     .. topic:: Example usage
 

--- a/src/tidytcells/mh/_standardize.py
+++ b/src/tidytcells/mh/_standardize.py
@@ -26,7 +26,7 @@ def standardize(
     log_failures: Optional[bool] = None,
     gene: Optional[str] = None,
     suppress_warnings: Optional[bool] = None,
-) -> tuple:
+) -> Optional[str]:
     """
     Attempt to standardize an MH gene / allele symbol to be IMGT-compliant.
 
@@ -89,7 +89,7 @@ def standardize(
         If `species` is unsupported, then the function does not attempt to standardize, and returns the unaltered `symbol` string.
         Else follows the behvaiour as set by `on_fail`.
     :rtype:
-        Union[str, None]
+        Optional[str]
 
     .. topic:: Example usage
 
@@ -198,7 +198,10 @@ def standardize(
         best_attempt_standardised_symbol = None
         best_attempt_species = None
 
-        for species, StandardizedMhSymbolClass in SUPPORTED_SPECIES_AND_THEIR_STANDARDIZERS.items():
+        for (
+            species,
+            StandardizedMhSymbolClass,
+        ) in SUPPORTED_SPECIES_AND_THEIR_STANDARDIZERS.items():
             standardized_tr_symbol = StandardizedMhSymbolClass(symbol)
             invalid_reason = standardized_tr_symbol.get_reason_why_invalid()
 
@@ -252,7 +255,7 @@ def standardize(
     return symbol
 
 
-def standardise(*args, **kwargs):
+def standardise(*args, **kwargs) -> Optional[str]:
     """
     Alias for :py:func:`tidytcells.mh.standardize`.
     """

--- a/src/tidytcells/tr/_standardize.py
+++ b/src/tidytcells/tr/_standardize.py
@@ -27,7 +27,7 @@ def standardize(
     log_failures: Optional[str] = None,
     gene: Optional[str] = None,
     suppress_warnings: Optional[bool] = None,
-) -> str:
+) -> Optional[str]:
     """
     Attempt to standardize a TR gene / allele symbol to be IMGT-compliant.
 
@@ -222,9 +222,14 @@ def standardize(
         best_attempt_standardised_symbol = None
         best_attempt_species = None
 
-        for species, StandardizedTrSymbolClass in SUPPORTED_SPECIES_AND_THEIR_STANDARDIZERS.items():
+        for (
+            species,
+            StandardizedTrSymbolClass,
+        ) in SUPPORTED_SPECIES_AND_THEIR_STANDARDIZERS.items():
             standardized_tr_symbol = StandardizedTrSymbolClass(symbol)
-            invalid_reason = standardized_tr_symbol.get_reason_why_invalid(enforce_functional)
+            invalid_reason = standardized_tr_symbol.get_reason_why_invalid(
+                enforce_functional
+            )
 
             if invalid_reason is None:
                 return standardized_tr_symbol.compile(precision)
@@ -246,7 +251,7 @@ def standardize(
             return None
         return symbol
 
-    if not species in SUPPORTED_SPECIES_AND_THEIR_STANDARDIZERS:
+    if species not in SUPPORTED_SPECIES_AND_THEIR_STANDARDIZERS:
         if log_failures:
             _utils.warn_unsupported_species(species, "TR", logger)
         return symbol
@@ -274,7 +279,7 @@ def standardize(
     return symbol
 
 
-def standardise(*args, **kwargs):
+def standardise(*args, **kwargs) -> Optional[str]:
     """
     Alias for :py:func:`tidytcells.tr.standardize`.
     """

--- a/src/tidytcells/tr/_standardize.py
+++ b/src/tidytcells/tr/_standardize.py
@@ -89,7 +89,7 @@ def standardize(
         If `species` is unsupported, then the function does not attempt to standardize , and returns the unaltered `symbol` string.
         Else follows the behaviour as set by `on_fail`.
     :rtype:
-        Union[str, None]
+        Optional[str]
 
     .. topic:: Example usage
 


### PR DESCRIPTION
* Some functions had inaccurate return type labels in source code, this has been fixed
* The type annotations in the function docstrings have also been updated