### PR TITLE
Max reconstr length

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check out branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: set up python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: build wheel and source tarball
         run: python3 -m build
       - name: store distribution packages
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -32,7 +32,7 @@ jobs:
       id-token: write
     steps:
       - name: download dists
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: build wheel and source tarball
         run: python3 -m build
       - name: store distribution packages
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -32,7 +32,7 @@ jobs:
       id-token: write
     steps:
       - name: download dists
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Set up python
         uses: actions/setup-python@v6
         with:

--- a/scripts/script_utility.py
+++ b/scripts/script_utility.py
@@ -126,8 +126,7 @@ def get_ig_j_gene_sequence_data(species: str) -> dict:
 
 def get_v_gene_sequence_data(species: str, gene_groups: Tuple[str]) -> dict:
     labels = ("FR1-IMGT", "CDR1-IMGT", "FR2-IMGT", "CDR2-IMGT", "FR3-IMGT", "V-REGION")
-    return get_gene_sequence_data(labels, gene_groups, species)
-
+    return omit_incomplete_regions(get_gene_sequence_data(labels, gene_groups, species))
 
 def get_d_gene_sequence_data(species: str, gene_groups: Tuple[str]) -> dict:
     labels = ("D-REGION",)
@@ -151,6 +150,20 @@ def get_j_gene_sequence_data(species: str, gene_groups: Tuple[str]) -> dict:
             data["TRAJ7*01"]["J-MOTIF"] = "LGKG"
 
     return add_j_motifs(data)
+
+def omit_incomplete_regions(v_aa_dict):
+    for allele, seq_data in v_aa_dict.items():
+        # Remove any empty sequences
+        for region in ("CDR1-IMGT", "CDR2-IMGT", "FR1-IMGT", "FR2-IMGT", "FR3-IMGT", "V-REGION"):
+            if region in seq_data and seq_data[region] == "":
+                seq_data.pop(region)
+
+        # Remove CDR1 if FR1 is missing and V starts with CDR1 (CDR1 is likely incomplete)
+        if ("V-REGION" in seq_data) and ("FR1-IMGT" not in seq_data) and ("CDR1-IMGT" in seq_data):
+            if seq_data["V-REGION"].startswith(seq_data["CDR1-IMGT"]):
+                seq_data.pop("CDR1-IMGT")
+
+    return v_aa_dict
 
 
 def get_gene_sequence_data(

--- a/src/tidytcells/_resources/homosapiens_tr_aa_sequences.json
+++ b/src/tidytcells/_resources/homosapiens_tr_aa_sequences.json
@@ -3257,7 +3257,6 @@
     },
     "TRAV8-4*07": {
         "functionality": "(F)",
-        "CDR1-IMGT": "VEPY",
         "FR2-IMGT": "LFWYVQYPNQGLQLLLK",
         "CDR2-IMGT": "YTTGATLV",
         "FR3-IMGT": "KGINGFEAEFKKSETSFHLTKPSAHMTDPAEYFC",
@@ -3265,7 +3264,6 @@
     },
     "TRBV5-4*04": {
         "functionality": "(F)",
-        "CDR1-IMGT": "T",
         "FR2-IMGT": "VSWYQQALGQGPQFIFQ",
         "CDR2-IMGT": "YYREEE",
         "FR3-IMGT": "NGRGNSPPRFSGLQFPNYSSELNVNALELDDSALYLC",
@@ -3273,7 +3271,6 @@
     },
     "TRBV7-9*07": {
         "functionality": "(F)",
-        "CDR1-IMGT": "HNR",
         "FR2-IMGT": "LYWYRQTLGQGPEFLTY",
         "CDR2-IMGT": "FQNEAQ",
         "FR3-IMGT": "LEKSRLLSDRFSAERPKGSFSTLEIQRTEEGDSAMYLC",

--- a/src/tidytcells/_resources/musmusculus_tr_aa_sequences.json
+++ b/src/tidytcells/_resources/musmusculus_tr_aa_sequences.json
@@ -3634,7 +3634,6 @@
     },
     "TRAV14D-2*02": {
         "functionality": "(F)",
-        "CDR1-IMGT": "STFDY",
         "FR2-IMGT": "FPWYRQFPRESPALLIA",
         "CDR2-IMGT": "ISLVSNK",
         "FR3-IMGT": "KEDGRFTIFFNKREKKLSLHITDSQPGDSATYFC",
@@ -3642,7 +3641,6 @@
     },
     "TRAV9D-4*03": {
         "functionality": "(F)",
-        "CDR1-IMGT": "",
         "FR2-IMGT": "IRGRVQYPRQGLQLLLK",
         "CDR2-IMGT": "YYSGDPVV",
         "FR3-IMGT": "QGVNGFEAEFSKSNSSFHLRKASVHWSDSAVYFC",

--- a/src/tidytcells/_standardized_junction/standardized_junction.py
+++ b/src/tidytcells/_standardized_junction/standardized_junction.py
@@ -35,7 +35,7 @@ class JunctionStandardizer(ABC):
     def __init__(self, seq: str, locus: str, j_symbol: str, v_symbol: str,
                  enforce_functional_v: bool = True, enforce_functional_j: bool = False,
                  allow_c_correction: bool = False, allow_fw_correction: bool = False,
-                 allow_v_reconstruction: bool = False, allow_j_reconstruction: bool = False) -> None:
+                 max_v_reconstruction: int = 1, max_j_reconstruction: int = 1) -> None:
         self.orig_seq = seq
         self.corrected_seq = seq
         self.locus = locus
@@ -45,8 +45,8 @@ class JunctionStandardizer(ABC):
         self.enforce_functional_j = enforce_functional_j
         self.allow_c_correction = allow_c_correction
         self.allow_fw_correction = allow_fw_correction
-        self.allow_v_reconstruction = allow_v_reconstruction
-        self.allow_j_reconstruction = allow_j_reconstruction
+        self.max_v_reconstruction = max_v_reconstruction
+        self.max_j_reconstruction = max_j_reconstruction
         self.corrected_first_aa = False
         self.corrected_last_aa = False
 
@@ -235,7 +235,7 @@ class JunctionStandardizer(ABC):
             elif len(seq) < new_seq_len:
                 reconstruction_length = new_seq_len - len(seq)
 
-                if reconstruction_length <= 1 or self.allow_j_reconstruction:
+                if reconstruction_length <= self.max_j_reconstruction:
                     end_j_idx = j_conserved_idx + 1
                     start_j_idx = end_j_idx - reconstruction_length
 
@@ -290,7 +290,7 @@ class JunctionStandardizer(ABC):
             if v_conserved_idx < v_offset:
                 reconstructed_aas = alignment_details["v_region"][v_conserved_idx:][:v_offset]
 
-                if len(reconstructed_aas) <= 1 or self.allow_v_reconstruction:
+                if len(reconstructed_aas) <= self.max_v_reconstruction:
                     new_seq = reconstructed_aas + seq
                     corrected_seqs.add(new_seq)
 

--- a/src/tidytcells/junction/_standardize.py
+++ b/src/tidytcells/junction/_standardize.py
@@ -34,8 +34,8 @@ def standardize(
     allow_fw_correction: Optional[bool] = None,
     enforce_functional_v: Optional[bool] = None,
     enforce_functional_j: Optional[bool] = None,
-    allow_v_reconstruction: Optional[bool] = None,
-    allow_j_reconstruction: Optional[bool] = None,
+    max_v_reconstruction: Optional[int] = None,
+    max_j_reconstruction: Optional[int] = None,
     log_failures: Optional[bool] = None,
     suppress_warnings: Optional[bool] = None,
 ) -> Junction:
@@ -104,17 +104,19 @@ def standardize(
         Defaults to ``False``.
     :type enforce_functional_j:
         bool
-    :param allow_v_reconstruction:
-        Whether to allow more than just the 1 conserved C amino acid to be re-constructed from the V gene.
-        It is recommended to only set this value to True if V symbol information is supplied.
-        Defaults to ``False``.
-    :type allow_v_reconstruction:
+    :param max_v_reconstruction:
+        The maximum number of amino acids to reconstruct based on V gene information.
+        Defaults to 1 (only construct the conserved C). It is recommended to only set this number
+        to a value greater than 1 if V symbol information is supplied, and generally not recommended to set
+        the value larger than 3.
+    :type max_v_reconstruction:
         bool
-    :param allow_j_reconstruction:
-        Whether to allow more than just the 1 conserved F / W / C amino acid to be re-constructed from the J gene.
-        It is recommended to only set this value to True if J symbol information is supplied.
-        Defaults to ``False``.
-    :type allow_j_reconstruction:
+    :param max_j_reconstruction:
+        The maximum number of amino acids to reconstruct based on J gene information.
+        Defaults to 1 (only construct the conserved F / W / C). It is recommended to only set this number
+        to a value greater than 1 if J symbol information is supplied, and generally not recommended to set
+        the value larger than 3.
+    :type max_j_reconstruction:
         bool
     :param log_failures:
         Report standardization failures through logging (at level ``WARNING``).
@@ -358,16 +360,16 @@ def standardize(
         .throw_error_if_not_of_type(bool)
         .value
     )
-    allow_v_reconstruction = (
-        Parameter(allow_v_reconstruction, "allow_v_reconstruction")
-        .set_default(False)
-        .throw_error_if_not_of_type(bool)
+    max_v_reconstruction = (
+        Parameter(max_v_reconstruction, "max_v_reconstruction")
+        .set_default(1)
+        .throw_error_if_not_of_type(int)
         .value
     )
-    allow_j_reconstruction = (
-        Parameter(allow_j_reconstruction, "allow_j_reconstruction")
-        .set_default(False)
-        .throw_error_if_not_of_type(bool)
+    max_j_reconstruction = (
+        Parameter(max_j_reconstruction, "max_j_reconstruction")
+        .set_default(1)
+        .throw_error_if_not_of_type(int)
         .value
     )
     suppress_warnings_inverted = (
@@ -417,8 +419,8 @@ def standardize(
                                                       allow_fw_correction=allow_fw_correction,
                                                       enforce_functional_v=enforce_functional_v,
                                                       enforce_functional_j=enforce_functional_j,
-                                                      allow_v_reconstruction=allow_v_reconstruction,
-                                                      allow_j_reconstruction=allow_j_reconstruction).result
+                                                      max_v_reconstruction=max_v_reconstruction,
+                                                      max_j_reconstruction=max_j_reconstruction).result
 
     if (not result.is_standardized) and log_failures:
         _utils.warn_result_failure(

--- a/tests/test_junction.py
+++ b/tests/test_junction.py
@@ -143,7 +143,7 @@ class Teststandardize:
         )
     )
     def test_various_examples(self, seq, j_symbol, v_symbol, locus, species, expected):
-        result = junction.standardize(seq=seq, j_symbol=j_symbol, v_symbol=v_symbol, species=species, locus=locus, allow_c_correction=True, allow_fw_correction=True, allow_v_reconstruction=True, allow_j_reconstruction=True, enforce_functional_j=True)
+        result = junction.standardize(seq=seq, j_symbol=j_symbol, v_symbol=v_symbol, species=species, locus=locus, allow_c_correction=True, allow_fw_correction=True, max_v_reconstruction=3, max_j_reconstruction=8, enforce_functional_j=True)
 
         assert result.junction == expected
         assert result.species == species


### PR DESCRIPTION
Hi Yuta, 

These are some minor fixes I ended up relying on for the IEDB work:
- There were some incomplete CDR1s in the sequences_aa json files as a result of not the complete V region being reported, those are now filtered out when downloading data, and removed from the json files
- Instead of setting allow_v/j_reconstruction to true/false, I replaced this parameter with a max_v/j_reconstruction length. This gives the user a bit more power to filter out obvious nonsense results (e.g., capping reconstruction at ~3 amino acids on either side), or to completely disallow any reconstruction (not even conserved aa's) and only read in the junction, by setting it to 0. Setting the new parameter max_v/j_reconstruction to 1 has the same effect as setting the old parameter allow_v/j_reconstruction to False. 


Addresses these issues: https://github.com/yutanagano/tidytcells/issues/131  https://github.com/yutanagano/tidytcells/issues/130 