### PR TITLE
Minor updates

### DIFF
--- a/scripts/script_utility.py
+++ b/scripts/script_utility.py
@@ -148,6 +148,8 @@ def get_j_gene_sequence_data(species: str, gene_groups: Tuple[str]) -> dict:
         if "TRAJ" in gene_groups:
             data["TRAJ7*01"]["J-conserved"] = "L"
             data["TRAJ7*01"]["J-MOTIF"] = "LGKG"
+            data["TRAJ44*01"]["J-conserved"] = "L"
+            data["TRAJ44*01"]["J-MOTIF"] = "LGAG"
 
     return add_j_motifs(data)
 

--- a/src/tidytcells/_resources/musmusculus_tr_aa_sequences.json
+++ b/src/tidytcells/_resources/musmusculus_tr_aa_sequences.json
@@ -4029,7 +4029,8 @@
     },
     "TRAJ44*01": {
         "functionality": "ORF",
-        "J-REGION": "VTGSGGKLTLGAGTRLQVNL"
+        "J-REGION": "VTGSGGKLTLGAGTRLQVNL",
+        "J-MOTIF": "LGAG"
     },
     "TRAJ45*01": {
         "functionality": "F",

--- a/src/tidytcells/_standardized_junction/standardized_junction.py
+++ b/src/tidytcells/_standardized_junction/standardized_junction.py
@@ -238,7 +238,6 @@ class JunctionStandardizer(ABC):
           2. An unambiguous correction can be determined (no disagreement between alignments)
         '''
 
-        # corrected_seqs = set()
         corrected_seq_with_j_gene = []
 
         alignment_too_long = []

--- a/src/tidytcells/_standardized_junction/standardized_junction.py
+++ b/src/tidytcells/_standardized_junction/standardized_junction.py
@@ -63,11 +63,14 @@ class JunctionStandardizer(ABC):
         self.j_alignments = self.align_j()
         self.v_alignments = self.align_v()
 
-        self.corrected_seq = self.correct_seq_j_side(self.corrected_seq)
-        self.corrected_seq = self.correct_seq_v_side(self.corrected_seq)
+        if len(self.j_alignments) > 0:
+            self.corrected_seq = self.correct_seq_j_side(self.corrected_seq)
+
+        if len(self.v_alignments) > 0:
+            self.corrected_seq = self.correct_seq_v_side(self.corrected_seq)
 
         if len(self.corrected_seq) < 6:
-            self.reasons_invalid.append("junction too short")
+            self.reasons_invalid.append("Junction too short")
 
     def get_aa_dict_from_symbol(self, gene) -> dict:
         '''
@@ -86,13 +89,13 @@ class JunctionStandardizer(ABC):
         # if symbol is an allele, return only info for the given allele
         if "*" in symbol:
             if gene not in symbol:
-                self.reasons_invalid.append(f"not a {gene} gene: {symbol}")
+                self.reasons_invalid.append(f"not a {gene} gene: {symbol} ({self._species})")
                 return dict()
 
             if symbol in  self._sequence_dictionary:
                 return {symbol: self._sequence_dictionary[symbol]}
             else:
-                self.reasons_invalid.append("no sequence information known for " + symbol)
+                self.reasons_invalid.append(f"no sequence information known for {symbol} ({self._species})")
 
         # if symbol is less specific than allele, retrieve any alleles that are valid extensions of the given symbol
         enforce_functional = self.enforce_functional_v if gene == "V" else self.enforce_functional_j
@@ -175,8 +178,11 @@ class JunctionStandardizer(ABC):
 
         if len(best_alignments) == 0:
             err = "J alignment unsuccessful"
+
             if self.j_symbol is not None:
-                err += " for J symbol " + self.j_symbol
+                err += f" for J symbol {self.j_symbol} ({self._species})"
+            else:
+                err += f" for any J symbol ({self._species})"
 
             if len(self.j_aa_dict) == 0:
                 err += ": no known sequence information"
@@ -197,8 +203,11 @@ class JunctionStandardizer(ABC):
 
         if len(best_alignments) == 0:
             err = "V alignment unsuccessful"
+
             if self.v_symbol is not None:
-                err += " for V symbol " + self.v_symbol
+                err += f" for V symbol {self.v_symbol} ({self._species})"
+            else:
+                err += " for any V symbol"
 
             if len(self.v_aa_dict) == 0:
                 err += ": no known sequence information"
@@ -218,6 +227,8 @@ class JunctionStandardizer(ABC):
         '''
 
         corrected_seqs = set()
+
+        alignment_too_long = []
 
         for alignment_details in self.j_alignments:
             j_conserved_idx = alignment_details["j_conserved_idx"]
@@ -241,6 +252,8 @@ class JunctionStandardizer(ABC):
 
                     reconstructed_aas = alignment_details["j_region"][start_j_idx:end_j_idx]
                     corrected_seqs.add(seq + reconstructed_aas)
+                else:
+                    alignment_too_long.append(f"{alignment_details['gene']} ({self._species}): Alignment successful but reconstruction too long ({reconstruction_length})")
 
         if len(corrected_seqs) > 1:
             # When Junction-reconstruction results are ambiguous (different J's)
@@ -259,7 +272,8 @@ class JunctionStandardizer(ABC):
                 return seq
 
         if len(corrected_seqs) == 0:
-            self.reasons_invalid.append(f"J side reconstruction unsuccessful.")
+            self.reasons_invalid.append(f"J side reconstruction unsuccessful")
+            self.reasons_invalid.extend(alignment_too_long)
             return seq
 
         return corrected_seqs.pop()
@@ -274,6 +288,7 @@ class JunctionStandardizer(ABC):
           2. An unambiguous correction can be determined (no disagreement between alignments)
         '''
         corrected_seqs = set()
+        alignment_too_long = []
 
         for alignment_details in self.v_alignments:
             v_conserved_idx = alignment_details["v_conserved_idx"]
@@ -289,10 +304,13 @@ class JunctionStandardizer(ABC):
 
             if v_conserved_idx < v_offset:
                 reconstructed_aas = alignment_details["v_region"][v_conserved_idx:][:v_offset]
+                reconstruction_length = len(reconstructed_aas)
 
-                if len(reconstructed_aas) <= self.max_v_reconstruction:
+                if reconstruction_length <= self.max_v_reconstruction:
                     new_seq = reconstructed_aas + seq
                     corrected_seqs.add(new_seq)
+                else:
+                    alignment_too_long.append(f"{alignment_details['gene']} ({self._species}): Alignment successful but reconstruction too long ({reconstruction_length})")
 
         corrected_seqs = {seq for seq in corrected_seqs if seq.startswith("C")}
 
@@ -300,7 +318,8 @@ class JunctionStandardizer(ABC):
             return "C" + seq
 
         if len(corrected_seqs) == 0:
-            self.reasons_invalid.append(f"V side reconstruction unsuccessful.")
+            self.reasons_invalid.append(f"V side reconstruction unsuccessful")
+            self.reasons_invalid.extend(alignment_too_long)
             return seq
 
         if len(corrected_seqs) > 1:

--- a/src/tidytcells/_standardized_junction/standardized_junction.py
+++ b/src/tidytcells/_standardized_junction/standardized_junction.py
@@ -49,11 +49,12 @@ class JunctionStandardizer(ABC):
         self.max_j_reconstruction = max_j_reconstruction
         self.corrected_first_aa = False
         self.corrected_last_aa = False
+        self.correction_j_genes = None
 
         self.reasons_invalid = []
         self._resolve_juncton()
 
-        self.result = Junction(self.orig_seq, self.get_reason_why_invalid(), self.corrected_seq, self._species)
+        self.result = Junction(self.orig_seq, self.get_reason_why_invalid(), self.corrected_seq, self._species, self.correction_j_genes)
 
 
     def _resolve_juncton(self):
@@ -64,7 +65,7 @@ class JunctionStandardizer(ABC):
         self.v_alignments = self.align_v()
 
         if len(self.j_alignments) > 0:
-            self.corrected_seq = self.correct_seq_j_side(self.corrected_seq)
+            self.corrected_seq, self.correction_j_genes = self.correct_seq_j_side(self.corrected_seq)
 
         if len(self.v_alignments) > 0:
             self.corrected_seq = self.correct_seq_v_side(self.corrected_seq)
@@ -216,6 +217,17 @@ class JunctionStandardizer(ABC):
 
         return best_alignments
 
+    def get_j_string_repr(self, seq, corrected_seq_with_j_gene):
+        '''
+        The J gene string representation concatenates all best-scoring J genes that match the sequence
+        '''
+
+        j_genes = sorted({j_gene for corrected_seq, j_gene in corrected_seq_with_j_gene
+                          if corrected_seq == seq})
+
+        return ", ".join(j_genes)
+
+
     def correct_seq_j_side(self, seq):
         '''
         Compute corrected sequence for J side
@@ -226,7 +238,8 @@ class JunctionStandardizer(ABC):
           2. An unambiguous correction can be determined (no disagreement between alignments)
         '''
 
-        corrected_seqs = set()
+        # corrected_seqs = set()
+        corrected_seq_with_j_gene = []
 
         alignment_too_long = []
 
@@ -236,12 +249,11 @@ class JunctionStandardizer(ABC):
 
             new_seq_len = j_offset + j_conserved_idx + 1
 
-            # If any alignment matches perfectly, don't look any further
             if len(seq) == new_seq_len:
-                return seq
+                corrected_seq_with_j_gene.append((seq, alignment_details['gene']))
 
             elif len(seq) > new_seq_len:
-                corrected_seqs.add(seq[:new_seq_len])
+                corrected_seq_with_j_gene.append((seq[:new_seq_len], alignment_details['gene']))
 
             elif len(seq) < new_seq_len:
                 reconstruction_length = new_seq_len - len(seq)
@@ -251,9 +263,16 @@ class JunctionStandardizer(ABC):
                     start_j_idx = end_j_idx - reconstruction_length
 
                     reconstructed_aas = alignment_details["j_region"][start_j_idx:end_j_idx]
-                    corrected_seqs.add(seq + reconstructed_aas)
+                    # corrected_seqs.add(seq + reconstructed_aas)
+                    corrected_seq_with_j_gene.append((seq + reconstructed_aas, alignment_details['gene']))
                 else:
                     alignment_too_long.append(f"{alignment_details['gene']} ({self._species}): Alignment successful but reconstruction too long ({reconstruction_length})")
+
+        corrected_seqs = {corrected_seq for corrected_seq, j_gene in corrected_seq_with_j_gene}
+
+        # if the perfect match exists, keep only this
+        if seq in corrected_seqs:
+            return seq, self.get_j_string_repr(seq, corrected_seq_with_j_gene)
 
         if len(corrected_seqs) > 1:
             # When Junction-reconstruction results are ambiguous (different J's)
@@ -269,14 +288,15 @@ class JunctionStandardizer(ABC):
 
             if len(corrected_seqs) > 1:
                 self.reasons_invalid.append(f"J side reconstruction ambiguous: {corrected_seqs}")
-                return seq
+                return seq, None
 
         if len(corrected_seqs) == 0:
             self.reasons_invalid.append(f"J side reconstruction unsuccessful")
             self.reasons_invalid.extend(alignment_too_long)
-            return seq
+            return seq, None
 
-        return corrected_seqs.pop()
+        corrected_seq = corrected_seqs.pop()
+        return corrected_seq, self.get_j_string_repr(corrected_seq, corrected_seq_with_j_gene)
 
     def correct_seq_v_side(self, seq):
         '''

--- a/src/tidytcells/result/_junction.py
+++ b/src/tidytcells/result/_junction.py
@@ -8,11 +8,12 @@ class Junction:
     When failed, the error message(s) and attempted partially standardized CDR3 can be retrieved.
     '''
 
-    def __init__(self, original_input, error, corrected_junction=None, species=None):
+    def __init__(self, original_input, error, corrected_junction=None, species=None, j_gene_match=None):
         self._original_input = original_input
         self._error = error
         self._corrected_junction = corrected_junction
         self._species = species
+        self._j_gene_match = j_gene_match
 
     def __str__(self):
         str_repr = self.junction
@@ -63,3 +64,9 @@ class Junction:
     def species(self) -> str:
         '''The species used for the gene lookup to validate the CDR3 junction.'''
         return self._species
+
+    @property
+    def j_gene_match(self) -> str:
+        '''The closest matching J gene(s) that were used to validate or reconstruct the CDR3 junction.
+        If multiple J genes have an identical matching score, the returned gene names will be separated by ', ' '''
+        return self._j_gene_match

--- a/tests/test_junction.py
+++ b/tests/test_junction.py
@@ -52,6 +52,7 @@ class Teststandardize:
 
         assert result.junction == "CASSPGGADRRIDGYTF"
         assert result.is_standardized
+        assert result.j_gene_match == "TRBJ1-2"
         assert result.error is None
 
     def test_log_failures(self, caplog):
@@ -96,6 +97,7 @@ class Teststandardize:
         assert "Unsupported" in caplog.text
         assert "Unsupported" in result.error
         assert result.junction is None
+        assert result.j_gene_match is None
         assert not result.is_standardized
 
 
@@ -153,9 +155,11 @@ class Teststandardize:
             assert result.is_standardized
             assert result.error is None
             assert str(result) == expected
+
+            if j_symbol is not None:
+                assert j_symbol in result.j_gene_match
         else:
             assert not result.is_standardized
             assert result.error is not None
             assert len(result.error) > 0
             assert str(result) == ""
-


### PR DESCRIPTION
Hi Yuta!

This PR contains one new feature and some small fixes:

- To the `Junction` result object I added the property `j_gene_match`. This returns the J gene(s) that were used for the junction standardization. I only added this for the J gene (and not for V) because the J gene tends to have such significant CDR3 overlap that most of the time there is only one good J match (at least for TCR). I found this to be useful for annotating the curated IEDB data where the J genes are not always provided. 

- I added some more specific Junction error messages

- I added a J motif for another mouse J gene edge case similar to the previous one (I observed both in real experimental data) 


Let me know what you think :)